### PR TITLE
docs(rename): update travel-planner network reference in docker-compose.examples.yml

### DIFF
--- a/docker-compose.examples.yml
+++ b/docker-compose.examples.yml
@@ -81,7 +81,7 @@ services:
       - example-events-agent
       - example-mcp-server
     networks:
-      - agentops-network
+      - observability-stack-network
     restart: unless-stopped
     deploy:
       resources:


### PR DESCRIPTION
## Description
Fix example-travel-planner service to use the ```observability-stack-network``` network name.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Configuration change
- [ ] Documentation update
- [ ] Test addition/modification

## Related Issues
Fixes network error when running install.sh with example services enabled

## Testing
- [x] Local docker-compose deployment
- [x] Configuration validation

## Changes
Changed example-travel-planner service network from `agentops-network` to `observability-stack-network` to match other services in docker-compose.examples.yml.

## Checklist
- [x] My code follows the style guidelines
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally
