### PR TITLE
feat: Enable agent traces in OSD

### DIFF
--- a/.env
+++ b/.env
@@ -6,13 +6,14 @@
 # Comment out or leave empty to run only the core observability stack
 # Include additional compose files (comment out to disable)
 INCLUDE_COMPOSE_EXAMPLES=docker-compose.examples.yml
-#INCLUDE_COMPOSE_OTEL_DEMO=docker-compose.otel-demo.yml
+# INCLUDE_COMPOSE_OTEL_DEMO=docker-compose.otel-demo.yml
 
-OPENSEARCH_DOCKER_REPO=opensearchproject
+# OPENSEARCH_DOCKER_REPO=opensearchproject
+OPENSEARCH_DOCKER_REPO=opensearchstaging
 
 
 # OpenSearch Configuration
-OPENSEARCH_VERSION=3.5.0
+OPENSEARCH_VERSION=3.6.0
 OPENSEARCH_USER=admin
 OPENSEARCH_PASSWORD='My_password_123!@#'
 OPENSEARCH_HOST=opensearch
@@ -20,7 +21,7 @@ OPENSEARCH_PORT=9200
 OPENSEARCH_JAVA_OPTS=-Xms1g -Xmx1g
 
 # OpenSearch Dashboards Configuration
-OPENSEARCH_DASHBOARDS_VERSION=3.5.0
+OPENSEARCH_DASHBOARDS_VERSION=3.6.0
 OPENSEARCH_DASHBOARDS_PORT=5601
 
 # OpenTelemetry Collector Configuration

--- a/docker-compose/opensearch-dashboards/opensearch_dashboards.yml
+++ b/docker-compose/opensearch-dashboards/opensearch_dashboards.yml
@@ -80,3 +80,4 @@ data_source.enabled: true
 data_source.ssl.verificationMode: none
 explore.discoverTraces.enabled: true
 datasetManagement.enabled: true
+explore.agentTraces.enabled: true


### PR DESCRIPTION
### Description
* Enable agent traces. 
* Use `opensearchstaging` docker repo prior to 3.6 release (required for pulling in agent-traces)

### Testing 

Verified agent traces are flowing and visible in UI 

<img width="1390" height="1020" alt="image" src="https://github.com/user-attachments/assets/b0bb32ac-357c-475d-bf79-8671f3eae803" />


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
