### PR TITLE
Enable dark mode, explore metrics, and UI enhancements for Dashboards

### DIFF
--- a/docker-compose/opensearch-dashboards/opensearch_dashboards.yml
+++ b/docker-compose/opensearch-dashboards/opensearch_dashboards.yml
@@ -75,9 +75,17 @@ csp.warnLegacyBrowsers: false
 savedObjects.maxImportPayloadBytes: 26214400
 
 explore.enabled: true
+explore.discoverTraces.enabled: true
+explore.discoverMetrics.enabled: true
+explore.agentTraces.enabled: true
 workspace.enabled: true
 data_source.enabled: true
 data_source.ssl.verificationMode: none
-explore.discoverTraces.enabled: true
 datasetManagement.enabled: true
-explore.agentTraces.enabled: true
+data.savedQueriesNewUI.enabled: true
+opensearchDashboards.branding.useExpandedHeader: false
+
+uiSettings.overrides.theme:darkMode: true
+uiSettings.overrides.theme:enableUserControl: false
+uiSettings.overrides.home:useNewHomePage: true
+uiSettings.overrides.query:enhancements:enabled: true


### PR DESCRIPTION
## Summary

Enables dark mode by default and additional UI enhancements for OpenSearch Dashboards.

## Changes

- Enable dark mode with user control disabled
- Enable explore.discoverMetrics
- Enable data.savedQueriesNewUI
- Disable expanded header branding
- Enable new home page and query enhancements  

## Testing  

Verified metrics explorer is working and dark mode enabled by default  

<img width="1507" height="985" alt="image" src="https://github.com/user-attachments/assets/68406e38-749f-4afa-93e6-41c57c495286" />
