### PR TITLE
fix: add @timestamp mapping to OTLP logs pipeline

### DIFF
--- a/docker-compose/data-prepper/pipelines.yaml
+++ b/docker-compose/data-prepper/pipelines.yaml
@@ -36,6 +36,11 @@ otel-logs-pipeline:
       name: "otlp-pipeline"
   buffer:
     bounded_blocking:
+  processor:
+    - copy_values:
+        entries:
+          - from_key: "time"
+            to_key: "@timestamp"
   # Write processed logs to OpenSearch
   sink:
     - opensearch:


### PR DESCRIPTION
### Description
  - Data Prepper's OTLP logs source maps timeUnixNano to a time field but does not populate @timestamp, which breaks time-based queries and sorting in OpenSearch/Dashboards
  - Adds a copy_values processor to otel-logs-pipeline that copies the time field (already ISO 8601) into @timestamp

### Issues Resolved
Fixes: https://github.com/opensearch-project/observability-stack/issues/34

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
