### PR TITLE
fix: correct sed pattern to uncomment OTEL demo env var

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -368,7 +368,7 @@ configure_environment() {
     fi
     
     if [[ "$INCLUDE_OTEL_DEMO" =~ ^[Yy]$ ]]; then
-        sed -i.bak 's/^#INCLUDE_COMPOSE_OTEL_DEMO=/INCLUDE_COMPOSE_OTEL_DEMO=/' .env
+        sed -i.bak 's/^# *INCLUDE_COMPOSE_OTEL_DEMO=/INCLUDE_COMPOSE_OTEL_DEMO=/' .env
         print_info "OpenTelemetry Demo enabled"
     fi
     


### PR DESCRIPTION
### Description
The .env file has a space after # in the INCLUDE_COMPOSE_OTEL_DEMO line, but the sed pattern in install.sh expected no space. This caused the OTel Demo to silently not start even when the user selected Y.

### Issues Resolved
Fixes #33 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

