### PR TITLE
Refresh installer CLI UI: purple theme, cleaner layout, better CX

### DIFF
--- a/demo-install.sh
+++ b/demo-install.sh
@@ -11,6 +11,7 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 MAGENTA='\033[0;35m'
 CYAN='\033[0;36m'
+PURPLE='\033[0;35m'
 BOLD='\033[1m'
 DIM='\033[2m'
 RESET='\033[0m'
@@ -23,17 +24,16 @@ STAR="★"
 
 clear
 
-echo -e "\n${CYAN}${BOLD}╔════════════════════════════════════════════════════════════╗${RESET}"
-echo -e "${CYAN}${BOLD}║                                                            ║${RESET}"
-echo -e "${CYAN}${BOLD}║              🔭 Observability Stack Installer v0.1                    ║${RESET}"
-echo -e "${CYAN}${BOLD}║                                                            ║${RESET}"
-echo -e "${CYAN}${BOLD}║            Open-source Agent Observability                 ║${RESET}"
-echo -e "${CYAN}${BOLD}║                                                            ║${RESET}"
-echo -e "${CYAN}${BOLD}╚════════════════════════════════════════════════════════════╝${RESET}\n"
+echo -e ""
+echo -e "  ${PURPLE}${BOLD}🔭 Observability Stack${RESET}"
+echo -e ""
+echo -e "  ${DIM}Installer v0.1${RESET}"
+echo -e "  ${DIM}Agents, Services, Logs, Metrics, Traces & Evals${RESET}"
+echo -e ""
 
 sleep 1
 
-echo -e "${BLUE}${BOLD}${ARROW}${RESET} ${BOLD}Checking system requirements...${RESET}"
+echo -e "${PURPLE}${BOLD}${ARROW}${RESET} ${BOLD}Checking system requirements...${RESET}"
 sleep 0.5
 echo -e "${GREEN}${CHECK}${RESET} Git installed: git version 2.39.0"
 sleep 0.3
@@ -45,7 +45,7 @@ echo -e "${GREEN}${CHECK}${RESET} Available memory: 16GB"
 sleep 0.5
 
 echo ""
-echo -e "${BLUE}${BOLD}${ARROW}${RESET} ${BOLD}Configuration${RESET}"
+echo -e "${PURPLE}${BOLD}${ARROW}${RESET} ${BOLD}Configuration${RESET}"
 echo ""
 sleep 0.5
 echo -e "${BOLD}Installation directory${RESET} ${DIM}(default: observability-stack)${RESET}: observability-stack"
@@ -58,13 +58,13 @@ echo -e "${BOLD}Customize OpenSearch credentials?${RESET} ${DIM}(y/N)${RESET}: N
 sleep 0.5
 
 echo ""
-echo -e "${BLUE}${BOLD}${ARROW}${RESET} ${BOLD}Cloning Observability Stack repository...${RESET}"
+echo -e "${PURPLE}${BOLD}${ARROW}${RESET} ${BOLD}Cloning Observability Stack repository...${RESET}"
 sleep 1
 echo -e "${GREEN}${CHECK}${RESET} Repository cloned to observability-stack"
 sleep 0.5
 
 echo ""
-echo -e "${BLUE}${BOLD}${ARROW}${RESET} ${BOLD}Configuring environment...${RESET}"
+echo -e "${PURPLE}${BOLD}${ARROW}${RESET} ${BOLD}Configuring environment...${RESET}"
 sleep 0.5
 echo -e "${DIM}  Example services enabled${RESET}"
 sleep 0.3
@@ -72,7 +72,7 @@ echo -e "${GREEN}${CHECK}${RESET} Environment configured"
 sleep 0.5
 
 echo ""
-echo -e "${BLUE}${BOLD}${ARROW}${RESET} ${BOLD}Pulling container images...${RESET}"
+echo -e "${PURPLE}${BOLD}${ARROW}${RESET} ${BOLD}Pulling container images...${RESET}"
 echo ""
 sleep 0.5
 
@@ -100,7 +100,7 @@ for i in "${!images[@]}"; do
         echo -ne "\r${DIM}[$num/$total]${RESET} ["
         printf "%${filled}s" | tr ' ' '█'
         printf "%${empty}s" | tr ' ' '░'
-        echo -ne "] ${percent}% ${CYAN}${spinner[$spin_idx]}${RESET} ${DIM}Pulling ${images[$i]}${RESET}"
+        echo -ne "] ${percent}% ${PURPLE}${spinner[$spin_idx]}${RESET} ${DIM}Pulling ${images[$i]}${RESET}"
         sleep 0.08
     done
     
@@ -116,7 +116,7 @@ echo -e "${GREEN}${CHECK}${RESET} Images ready: 6 pulled, 0 cached"
 sleep 0.5
 
 echo ""
-echo -e "${BLUE}${BOLD}${ARROW}${RESET} ${BOLD}Starting Observability Stack services...${RESET}"
+echo -e "${PURPLE}${BOLD}${ARROW}${RESET} ${BOLD}Starting Observability Stack services...${RESET}"
 echo ""
 sleep 1
 
@@ -136,7 +136,7 @@ echo -e "${GREEN}${CHECK}${RESET} Services started"
 sleep 0.5
 
 echo ""
-echo -e "${BLUE}${BOLD}${ARROW}${RESET} ${BOLD}Waiting for services to be ready...${RESET}"
+echo -e "${PURPLE}${BOLD}${ARROW}${RESET} ${BOLD}Waiting for services to be ready...${RESET}"
 echo ""
 sleep 0.5
 
@@ -161,26 +161,23 @@ echo -e "${GREEN}${CHECK}${RESET} Services are ready"
 sleep 1
 
 echo ""
-echo -e "${GREEN}${BOLD}╔════════════════════════════════════════════════════════════╗${RESET}"
-echo -e "${GREEN}${BOLD}║                                                            ║${RESET}"
-echo -e "${GREEN}${BOLD}║              ${STAR} Installation Complete! ${STAR}                    ║${RESET}"
-echo -e "${GREEN}${BOLD}║                                                            ║${RESET}"
-echo -e "${GREEN}${BOLD}╚════════════════════════════════════════════════════════════╝${RESET}"
+echo -e "  ${GREEN}${BOLD}${STAR} Observability Stack Install Complete! ${STAR}${RESET}"
 echo ""
 
-echo -e "${BOLD}Access Points:${RESET}"
-echo -e "  ${CYAN}${ARROW}${RESET} OpenSearch Dashboards: ${BOLD}http://localhost:5601${RESET}"
-echo -e "  ${CYAN}${ARROW}${RESET} Prometheus:            ${BOLD}http://localhost:9090${RESET}"
-echo -e "  ${CYAN}${ARROW}${RESET} OpenSearch API:        ${BOLD}https://localhost:9200${RESET}"
-echo -e "  ${CYAN}${ARROW}${RESET} Weather Agent:        ${BOLD}http://localhost:8000${RESET}"
-echo -e "  ${CYAN}${ARROW}${RESET} Travel Planner:       ${BOLD}http://localhost:8003${RESET}"
-echo -e "  ${CYAN}${ARROW}${RESET} OTel Demo Frontend:   ${BOLD}http://localhost:8080${RESET}"
-echo -e "  ${CYAN}${ARROW}${RESET} Load Generator:       ${BOLD}http://localhost:8089${RESET}"
-
+echo -e "${GREEN}${ARROW}${RESET} ${BOLD}UI:${RESET}        OpenSearch Dashboards  ${BOLD}http://localhost:5601${RESET}"
+echo -e "           ${DIM}Username: ${RESET}${BOLD}admin${RESET}  ${DIM}Password: ${RESET}${BOLD}My_password_123!@#${RESET}"
 echo ""
-echo -e "${BOLD}Credentials:${RESET}"
-echo -e "  ${CYAN}${ARROW}${RESET} Username: ${BOLD}admin${RESET}"
-echo -e "  ${CYAN}${ARROW}${RESET} Password: ${BOLD}My_password_123!@#${RESET}"
+echo -e "${GREEN}${ARROW}${RESET} ${BOLD}Send OTLP:${RESET} OTel Collector         ${BOLD}grpc://localhost:4317${RESET}"
+echo -e "                                      ${BOLD}http://localhost:4318${RESET}"
+echo ""
+
+echo -e "${DIM}Other Services:${RESET}"
+echo -e "  ${DIM}${ARROW} Prometheus:            http://localhost:9090${RESET}"
+echo -e "  ${DIM}${ARROW} OpenSearch API:        https://localhost:9200${RESET}"
+echo -e "  ${DIM}${ARROW} Weather Agent:         http://localhost:8000${RESET}"
+echo -e "  ${DIM}${ARROW} Travel Planner:        http://localhost:8003${RESET}"
+echo -e "  ${DIM}${ARROW} OTel Demo Frontend:    http://localhost:8080${RESET}"
+echo -e "  ${DIM}${ARROW} Load Generator:        http://localhost:8089${RESET}"
 
 echo ""
 echo -e "${BOLD}Useful Commands:${RESET}"
@@ -194,10 +191,10 @@ echo -e "  ${DIM}# Stop and remove data${RESET}"
 echo -e "  ${BOLD}cd observability-stack && docker compose down -v${RESET}"
 
 echo ""
-echo -e "${BOLD}Next Steps:${RESET}"
-echo -e "  1. Visit ${CYAN}http://localhost:5601${RESET} to explore your data"
-echo -e "  2. Check out ${CYAN}observability-stack/examples/${RESET} for instrumentation examples"
-echo -e "  3. Read ${CYAN}observability-stack/README.md${RESET} for detailed documentation"
+echo -e "${PURPLE}${BOLD}Next Steps:${RESET}"
+echo -e "  1. Visit ${PURPLE}http://localhost:5601${RESET} to explore your data"
+echo -e "  2. To send data, point your OTLP exporter at ${PURPLE}localhost:4317${RESET} (gRPC) or ${PURPLE}localhost:4318${RESET} (HTTP)"
+echo -e "  3. Learn more at ${PURPLE}https://opensearch.org/platform/observability/${RESET}"
 
 echo ""
 echo -e "${DIM}For support, visit: https://github.com/opensearch-project/observability-stack${RESET}"

--- a/install.sh
+++ b/install.sh
@@ -125,6 +125,7 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 MAGENTA='\033[0;35m'
 CYAN='\033[0;36m'
+PURPLE='\033[0;35m'
 BOLD='\033[1m'
 DIM='\033[2m'
 RESET='\033[0m'
@@ -140,17 +141,16 @@ DEFAULT_INSTALL_DIR="observability-stack"
 
 # Print functions
 print_header() {
-    echo -e "\n${CYAN}${BOLD}╔════════════════════════════════════════════════════════════╗${RESET}"
-    echo -e "${CYAN}${BOLD}║                                                            ║${RESET}"
-    echo -e "${CYAN}${BOLD}║              🔭 Observability Stack Installer v0.1                    ║${RESET}"
-    echo -e "${CYAN}${BOLD}║                                                            ║${RESET}"
-    echo -e "${CYAN}${BOLD}║            Open-source Agent Observability                 ║${RESET}"
-    echo -e "${CYAN}${BOLD}║                                                            ║${RESET}"
-    echo -e "${CYAN}${BOLD}╚════════════════════════════════════════════════════════════╝${RESET}\n"
+    echo -e ""
+    echo -e "  ${PURPLE}${BOLD}🔭 Observability Stack${RESET}"
+    echo -e ""
+    echo -e "  ${DIM}Installer v0.1${RESET}"
+    echo -e "  ${DIM}Agents, Services, Logs, Metrics, Traces & Evals${RESET}"
+    echo -e ""
 }
 
 print_step() {
-    echo -e "${BLUE}${BOLD}${ARROW}${RESET} ${BOLD}$1${RESET}"
+    echo -e "${PURPLE}${BOLD}${ARROW}${RESET} ${BOLD}$1${RESET}"
 }
 
 print_success() {
@@ -415,7 +415,7 @@ pull_images() {
     
     # Show spinner while building
     while kill -0 $build_pid 2>/dev/null; do
-        echo -ne "\r${DIM}Building custom OpenSearch image...${RESET} ${CYAN}${spinner[$spinner_idx]}${RESET}"
+        echo -ne "\r${DIM}Building custom OpenSearch image...${RESET} ${PURPLE}${spinner[$spinner_idx]}${RESET}"
         spinner_idx=$(( (spinner_idx + 1) % ${#spinner[@]} ))
         sleep 0.1
     done
@@ -501,7 +501,7 @@ EOF
             echo -ne "\r${DIM}[$current/$total]${RESET} ["
             printf "%${filled}s" | tr ' ' '█'
             printf "%${empty}s" | tr ' ' '░'
-            echo -ne "] ${percent}% ${CYAN}${spinner[$spinner_idx]}${RESET} ${DIM}Pulling ${image}${RESET}"
+            echo -ne "] ${percent}% ${PURPLE}${spinner[$spinner_idx]}${RESET} ${DIM}Pulling ${image}${RESET}"
             spinner_idx=$(( (spinner_idx + 1) % ${#spinner[@]} ))
             sleep 0.1
         done
@@ -654,33 +654,30 @@ wait_for_services() {
 # Print summary
 print_summary() {
     echo ""
-    echo -e "${GREEN}${BOLD}╔════════════════════════════════════════════════════════════╗${RESET}"
-    echo -e "${GREEN}${BOLD}║                                                            ║${RESET}"
-    echo -e "${GREEN}${BOLD}║              ${STAR} Installation Complete! ${STAR}                    ║${RESET}"
-    echo -e "${GREEN}${BOLD}║                                                            ║${RESET}"
-    echo -e "${GREEN}${BOLD}╚════════════════════════════════════════════════════════════╝${RESET}"
+    echo -e "  ${GREEN}${BOLD}${STAR} Observability Stack Install Complete! ${STAR}${RESET}"
     echo ""
-    
-    echo -e "${BOLD}Access Points:${RESET}"
-    echo -e "  ${CYAN}${ARROW}${RESET} OpenSearch Dashboards: ${BOLD}http://localhost:5601${RESET}"
-    echo -e "  ${CYAN}${ARROW}${RESET} Prometheus:            ${BOLD}http://localhost:9090${RESET}"
-    echo -e "  ${CYAN}${ARROW}${RESET} OpenSearch API:        ${BOLD}https://localhost:9200${RESET}"
-    
+
+    echo -e "${GREEN}${ARROW}${RESET} ${BOLD}UI:${RESET}        OpenSearch Dashboards  ${BOLD}http://localhost:5601${RESET}"
+    echo -e "           ${DIM}Username: ${RESET}${BOLD}$OPENSEARCH_USER${RESET}  ${DIM}Password: ${RESET}${BOLD}$OPENSEARCH_PASSWORD${RESET}"
+    echo ""
+    echo -e "${GREEN}${ARROW}${RESET} ${BOLD}Send OTLP:${RESET} OTel Collector         ${BOLD}grpc://localhost:4317${RESET}"
+    echo -e "                                      ${BOLD}http://localhost:4318${RESET}"
+    echo ""
+
+    echo -e "${DIM}Other Services:${RESET}"
+    echo -e "  ${DIM}${ARROW} Prometheus:            http://localhost:9090${RESET}"
+    echo -e "  ${DIM}${ARROW} OpenSearch API:        https://localhost:9200${RESET}"
+
     if [[ "$INCLUDE_EXAMPLES" =~ ^[Yy]$ ]]; then
-        echo -e "  ${CYAN}${ARROW}${RESET} Weather Agent:        ${BOLD}http://localhost:8000${RESET}"
-        echo -e "  ${CYAN}${ARROW}${RESET} Travel Planner:       ${BOLD}http://localhost:8003${RESET}"
+        echo -e "  ${DIM}${ARROW} Weather Agent:         http://localhost:8000${RESET}"
+        echo -e "  ${DIM}${ARROW} Travel Planner:        http://localhost:8003${RESET}"
     fi
-    
+
     if [[ "$INCLUDE_OTEL_DEMO" =~ ^[Yy]$ ]]; then
-        echo -e "  ${CYAN}${ARROW}${RESET} OTel Demo Frontend:   ${BOLD}http://localhost:8080${RESET}"
-        echo -e "  ${CYAN}${ARROW}${RESET} Load Generator:       ${BOLD}http://localhost:8089${RESET}"
+        echo -e "  ${DIM}${ARROW} OTel Demo Frontend:    http://localhost:8080${RESET}"
+        echo -e "  ${DIM}${ARROW} Load Generator:        http://localhost:8089${RESET}"
     fi
-    
-    echo ""
-    echo -e "${BOLD}Credentials:${RESET}"
-    echo -e "  ${CYAN}${ARROW}${RESET} Username: ${BOLD}$OPENSEARCH_USER${RESET}"
-    echo -e "  ${CYAN}${ARROW}${RESET} Password: ${BOLD}$OPENSEARCH_PASSWORD${RESET}"
-    
+
     echo ""
     echo -e "${BOLD}Useful Commands:${RESET}"
     echo -e "  ${DIM}# View logs${RESET}"
@@ -691,13 +688,13 @@ print_summary() {
     echo ""
     echo -e "  ${DIM}# Stop and remove data${RESET}"
     echo -e "  ${BOLD}cd $INSTALL_DIR && $CONTAINER_RUNTIME compose down -v${RESET}"
-    
+
     echo ""
-    echo -e "${BOLD}Next Steps:${RESET}"
-    echo -e "  1. Visit ${CYAN}http://localhost:5601${RESET} to explore your data"
-    echo -e "  2. Check out ${CYAN}$INSTALL_DIR/examples/${RESET} for instrumentation examples"
-    echo -e "  3. Read ${CYAN}$INSTALL_DIR/README.md${RESET} for detailed documentation"
-    
+    echo -e "${PURPLE}${BOLD}Next Steps:${RESET}"
+    echo -e "  1. Visit ${PURPLE}http://localhost:5601${RESET} to explore your data"
+    echo -e "  2. To send data, point your OTLP exporter at ${PURPLE}localhost:4317${RESET} (gRPC) or ${PURPLE}localhost:4318${RESET} (HTTP)"
+    echo -e "  3. Learn more at ${PURPLE}https://opensearch.org/platform/observability/${RESET}"
+
     echo ""
     echo -e "${DIM}For support, visit: https://github.com/opensearch-project/observability-stack${RESET}"
     echo ""
@@ -721,10 +718,10 @@ main() {
     # fi
     
     if [ "$INSTALL_METHOD" = "tui" ]; then
-        echo -e "${CYAN}${BOLD}Starting TUI installer...${RESET}\n"
+        echo -e "${PURPLE}${BOLD}Starting TUI installer...${RESET}\n"
         run_tui_installer
     else
-        echo -e "${CYAN}${BOLD}Starting installation...${RESET}\n"
+        echo -e "${PURPLE}${BOLD}Starting installation...${RESET}\n"
         run_manual_installer
     fi
 }


### PR DESCRIPTION
## Description

Refreshes the CLI installer UI for a cleaner, more customer-focused experience. Replaces fragile box-drawing borders (which broke across terminal widths and emoji rendering) with simple, reliable text formatting. Reorients the completion summary around the two things users care about most: where the UI is and where to send data.

## Changes

### Color theme - Purple
- Step arrows and spinners changed from blue/cyan to purple
- Header title in purple
- Next Steps section and URLs highlighted in purple
- Green retained for success indicators, completed arrows
- Red available for errors

### Header (before)
```
╔════════════════════════════════════════════════════════════╗
║              Observability Stack Installer v0.1            ║
║            Open-source Agent Observability                 ║
╚════════════════════════════════════════════════════════════╝
```

### Header (after)
```
  Observability Stack

  Installer v0.1
  Agents, Services, Logs, Metrics, Traces & Evals
```

### Completion summary (after)
- Observability Stack Install Complete!
- **UI** endpoint highlighted first with inline credentials
- **Send OTLP** endpoint (gRPC + HTTP) highlighted second
- Other services dimmed as secondary info
- Next Steps calls out Dashboards URL, OTLP endpoints, and https://opensearch.org/platform/observability/

## Why
- Box-drawing characters broke in terminals due to emoji double-width rendering
- Previous layout treated all endpoints equally - customers need UI and OTLP front and center
- Tagline updated from Open-source Agent Observability to Agents, Services, Logs, Metrics, Traces and Evals
- Link to opensearch.org/platform/observability/ replaces local examples path in Next Steps

## Testing
```bash
bash demo-install.sh
```
Verified clean rendering with no broken borders in macOS terminal.

Supersedes #32 (closed due to missing DCO signature).