### PR TITLE
fix: opensearch health check

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -137,7 +137,7 @@ services:
         soft: 65536
         hard: 65536
     healthcheck:
-      test: curl -s -k -u ${OPENSEARCH_USER}:${OPENSEARCH_PASSWORD} https://localhost:9200/_cluster/health | grep -E '"status":"(green|yellow)"'
+      test: curl -s -k -u ${OPENSEARCH_USER}:'${OPENSEARCH_PASSWORD}' https://localhost:9200/_cluster/health | grep -E '"status":"(green|yellow)"'
       start_period: 120s
       interval: 5s
       timeout: 10s


### PR DESCRIPTION
## Summary

  Single-character fix: wrap ${OPENSEARCH_PASSWORD} in single quotes in the OpenSearch healthcheck command to prevent shell interpretation of special characters.

## Description

### Problem
After PR #47 (0bc6786), the OpenSearch container reports as unhealthy. The default password contains special characters (!@#) that are interpreted by the shell when the healthcheck runs, causing curl to send a malformed password and fail authentication. Since all downstream services (data-prepper, opensearch-dashboards, etc.) depend on opensearch: service_healthy, the entire stack fails to start.

#### Root Cause

```
  The OpenSearch healthcheck in docker-compose.yml:140 passes the password unquoted:

  test: curl -s -k -u ${OPENSEARCH_USER}:${OPENSEARCH_PASSWORD} https://localhost:9200/_cluster/health ...

  The Dashboards healthcheck (line 207) was already correctly quoting the password:

  test: curl -f -u ${OPENSEARCH_USER}:'${OPENSEARCH_PASSWORD}' http://localhost:5601/api/status ...
```

#### Fix

Added single quotes around ${OPENSEARCH_PASSWORD} in the OpenSearch healthcheck to match the Dashboards pattern:

```
  - test: curl -s -k -u ${OPENSEARCH_USER}:${OPENSEARCH_PASSWORD} https://localhost:9200/_cluster/health | grep -E '"status":"(green|yellow)"'
  + test: curl -s -k -u ${OPENSEARCH_USER}:'${OPENSEARCH_PASSWORD}' https://localhost:9200/_cluster/health | grep -E '"status":"(green|yellow)"'
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
