### PR TITLE
fix: move README video below Components, use user-attachments URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 Observability Stack is an open-source stack designed for modern distributed systems. Built on OpenTelemetry, OpenSearch, and Prometheus, Observability Stack provides a complete, pre-configured infrastructure for monitoring microservices, web applications, and AI agents—with first-class support for agent observability through [OpenTelemetry Gen-AI Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/).
 
-https://github.com/opensearch-project/observability-stack/releases/download/v3.6.0-alpha.1/observability-stack-overview.mp4
-
 ![OpenSearch Observability Stack Architecture - docker-compose](./docs/observability-stack-arch-compose.excalidraw.png)
 
 ## Components
@@ -15,6 +13,10 @@ https://github.com/opensearch-project/observability-stack/releases/download/v3.6
 - **OpenSearch**: Stores and indexes logs and traces for search and analysis
 - **Prometheus**: Stores time-series metrics data
 - **OpenSearch Dashboards**: Provides web-based visualization and exploration
+
+## See it in action 
+
+https://github.com/user-attachments/assets/bef4c3ad-c64d-4db8-96f5-9ffd26bd0b03
 
 ## 🚀 Quickstart
 


### PR DESCRIPTION
- Move "See it in action" video from above Components to below it
- Replace release asset URL with user-attachments URL so the video embeds on GitHub