### PR TITLE
chore: add dependabot.yml with grouped updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  # All npm dependencies across docs/
+  - package-ecosystem: "npm"
+    directories:
+      - "/docs"
+      - "/docs/starlight-docs"
+    schedule:
+      interval: "weekly"
+    groups:
+      docs-npm:
+        patterns: ["*"]
+        group-by: dependency-name
+
+  # All Python dependencies across examples/
+  - package-ecosystem: "pip"
+    directories:
+      - "/examples/langchain/bedrock-financial-assistant"
+      - "/examples/strands/code-assistant"
+      - "/examples/plain-agents/weather-agent"
+    schedule:
+      interval: "weekly"
+    groups:
+      examples-python:
+        update-types: ["minor", "patch"]
+        group-by: dependency-name


### PR DESCRIPTION
Adds `.github/dependabot.yml` to group dependency updates and reduce PR noise.

Uses `directories` + `group-by: dependency-name` to consolidate updates into 2 PRs instead of 11+:

1. **docs-npm** — all npm deps across `/docs` and `/docs/starlight-docs`
2. **examples-python** — minor/patch Python deps across all example directories (major bumps kept separate)

Weekly schedule for both.