### PR TITLE
chore: add @ps48 as maintainer and code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default owners for all files
-*       @kylehounslow @goyamegh @vamsimanohar @anirudha
+*       @kylehounslow @goyamegh @vamsimanohar @anirudha @ps48

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -10,3 +10,4 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Megha Goyal | [goyamegh](https://github.com/goyamegh) | Amazon |
 | Vamsi Manohar | [vamsimanohar](https://github.com/vamsimanohar) | Amazon |
 | Anirudha (Ani) Jadhav | [anirudha](https://github.com/anirudha) | Amazon |
+| Shenoy Pratik Gurudatt | [ps48](https://github.com/ps48) | Amazon |


### PR DESCRIPTION
Add @ps48 as maintainer and code owner for the observability-stack repository.

**Contributions to observability-stack:**
- [enable discover experimental feature (#63)](https://github.com/opensearch-project/observability-stack/commit/9c9dc0a451840f3202819ff0234ad818ecb1a9e0)
- [add quotes to opensearch auth (#59)](https://github.com/opensearch-project/observability-stack/commit/9b88c8ef849aa9b7e442d2e7300bdd1b7f53031c)
- [update favicon (#58)](https://github.com/opensearch-project/observability-stack/commit/8d4ee6a9833dcffd52168ff06ff4eb5b2321e66c)
- [update doc relative paths remove agentops (#51)](https://github.com/opensearch-project/observability-stack/commit/07b26d1edf1ee8542e98de197d91cabc6f2c28fb)
- [update doc builds (#50)](https://github.com/opensearch-project/observability-stack/commit/ab1083b0db7faddd7c178fb6f7361a7e0a784bdd)
- [Feat/add documentation site (#49)](https://github.com/opensearch-project/observability-stack/commit/b1bba8e55165ba971f1981a77d08d1aa05b3a9d4)
- [fix opensearch health check (#48)](https://github.com/opensearch-project/observability-stack/commit/f92b0072f1dcf667513088d8ce246657d9150389)
- [fix: use template pattern for credential injection and improve docs (#47)](https://github.com/opensearch-project/observability-stack/commit/0bc6786e3b0913e2aebb6fa176ccbf2257765c30)
- [update ui links in home dashboard (#46)](https://github.com/opensearch-project/observability-stack/commit/228fccacbd27ddba10ce419a611bb763c42ffbcf)
- [feat(dashboards): add overview landing dashboard with architecture diagram and link descriptions (#45)](https://github.com/opensearch-project/observability-stack/commit/71a111e6fd291c6928bb8f9e3c9a401734a50384)
- [fix(otel-collector): flatten OTel Demo attributes to prevent OpenSearch mapping conflicts (#39)](https://github.com/opensearch-project/observability-stack/commit/aaa862a660ce32f90b69899b1d341f6d591963f9)
- [add logs processor to copy the time field to @timestamp (#36)](https://github.com/opensearch-project/observability-stack/commit/f7d7d4ba6211ab2dc74a496bdd21a69fea45160b)
- [Add support to ingest APM RED metrics into Prometheus (#35)](https://github.com/opensearch-project/observability-stack/commit/4b411a920635587bc4b006b01054b507458d3294)

Related .github issue: https://github.com/opensearch-project/.github/issues/472