### PR TITLE
feat: instrument plain-agents with opensearch-genai-observability-sdk-py

### DIFF
--- a/examples/plain-agents/multi-agent-planner/events-agent/Dockerfile
+++ b/examples/plain-agents/multi-agent-planner/events-agent/Dockerfile
@@ -7,8 +7,7 @@ RUN pip install --no-cache-dir \
     fastapi \
     uvicorn \
     httpx \
-    opentelemetry-api \
-    opentelemetry-sdk \
+    opensearch-genai-observability-sdk-py>=0.2.7 \
     opentelemetry-exporter-otlp-proto-grpc \
     opentelemetry-instrumentation-asgi
 

--- a/examples/plain-agents/multi-agent-planner/events-agent/main.py
+++ b/examples/plain-agents/multi-agent-planner/events-agent/main.py
@@ -2,6 +2,10 @@
 """
 Events Agent - Fetches local events for a destination.
 Supports fault injection for testing observability.
+
+Instrumented with opensearch-genai-observability-sdk-py:
+- register() replaces ~20 lines of manual TracerProvider/exporter setup
+- observe() + enrich() replace manual span creation + set_attribute() calls
 """
 
 import json
@@ -15,10 +19,7 @@ from uuid import uuid4
 import httpx
 from fastapi import FastAPI
 from opentelemetry import trace, metrics
-from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
 from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
 from opentelemetry.sdk.resources import Resource
@@ -26,6 +27,8 @@ from opentelemetry.trace import SpanKind, Status, StatusCode
 from opentelemetry.instrumentation.asgi import OpenTelemetryMiddleware
 from opentelemetry.propagate import inject
 from pydantic import BaseModel, Field
+
+from opensearch_genai_observability_sdk_py import Op, enrich, observe, register
 
 
 # MCP Server configuration
@@ -141,29 +144,25 @@ class ErrorResponse(BaseModel):
     agent_id: str
 
 
-def setup_telemetry(service_name: str, otlp_endpoint: str):
-    resource = Resource.create({
-        "service.name": service_name,
-        "service.version": "1.0.0",
-        "gen_ai.agent.id": AGENT_ID,
-        "gen_ai.agent.name": AGENT_NAME,
-    })
-    tracer_provider = TracerProvider(resource=resource)
-    tracer_provider.add_span_processor(
-        BatchSpanProcessor(OTLPSpanExporter(endpoint=otlp_endpoint, insecure=True))
-    )
-    trace.set_tracer_provider(tracer_provider)
-    metric_reader = PeriodicExportingMetricReader(
-        OTLPMetricExporter(endpoint=otlp_endpoint, insecure=True),
-        export_interval_millis=10000,
-    )
-    meter_provider = MeterProvider(resource=resource, metric_readers=[metric_reader])
-    metrics.set_meter_provider(meter_provider)
-    return trace.get_tracer(service_name), metrics.get_meter(service_name)
-
-
+# --- Telemetry setup ---
 otlp_endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
-tracer, meter = setup_telemetry("events-agent", otlp_endpoint)
+
+# One line replaces ~20 lines of TracerProvider + exporter setup
+register(
+    endpoint=f"grpc://{otlp_endpoint.replace('http://', '').replace('https://', '')}",
+    service_name="events-agent",
+    service_version="1.0.0",
+)
+
+# Metrics (SDK handles tracing only)
+# TODO: unify Resource with register() when SDK supports metrics
+resource = Resource.create({"service.name": "events-agent"})
+metric_reader = PeriodicExportingMetricReader(
+    OTLPMetricExporter(endpoint=otlp_endpoint, insecure=True),
+    export_interval_millis=10000,
+)
+meter_provider = MeterProvider(resource=resource, metric_readers=[metric_reader])
+metrics.set_meter_provider(meter_provider)
 
 inner_app = FastAPI(title="Events Agent", version="1.0.0")
 
@@ -182,41 +181,40 @@ async def health():
 @inner_app.post("/events")
 async def get_events(request: EventsRequest):
     model = random.choice(MODELS)
-    
+    provider = SYSTEMS[model]
+
     # Promote gen_ai attributes to the root HTTP span so the UI can read them
+    enrich(
+        model=model,
+        provider=provider,
+        agent_id=AGENT_ID,
+        input_messages=[{"role": "user", "parts": [{"type": "text", "content": f"Find events in {request.destination}"}]}],
+    )
     root_span = trace.get_current_span()
-    root_span.set_attribute("gen_ai.system", SYSTEMS[model])
     root_span.set_attribute("gen_ai.agent.name", AGENT_NAME)
-    root_span.set_attribute("gen_ai.request.model", model)
     root_span.set_attribute("gen_ai.operation.name", "invoke_agent")
-    root_span.set_attribute("gen_ai.input.messages", json.dumps(
-        [{"role": "user", "parts": [{"type": "text", "content": f"Find events in {request.destination}"}]}]
-    ))
-    
-    with tracer.start_as_current_span(
-        "invoke_agent",
-        kind=SpanKind.INTERNAL,
-        attributes={
-            "gen_ai.operation.name": "invoke_agent",
-            "gen_ai.agent.id": AGENT_ID,
-            "gen_ai.agent.name": AGENT_NAME,
-            "gen_ai.system": SYSTEMS[model],
-            "gen_ai.request.model": model,
-            "gen_ai.tool.definitions": json.dumps(TOOL_DEFINITIONS),
-        },
-    ) as span:
+
+    with observe(AGENT_NAME, op=Op.INVOKE_AGENT) as span:
+        enrich(
+            model=model,
+            provider=provider,
+            agent_id=AGENT_ID,
+            tool_definitions=TOOL_DEFINITIONS,
+        )
+
         destination = request.destination.lower()
         date = request.date or datetime.now().strftime("%Y-%m-%d")
         fault = request.fault
 
         # Synthetic "thinking" LLM call
-        with tracer.start_as_current_span("chat", kind=SpanKind.INTERNAL) as chat_span:
-            chat_span.set_attribute("gen_ai.operation.name", "chat")
-            chat_span.set_attribute("gen_ai.system", SYSTEMS[model])
-            chat_span.set_attribute("gen_ai.request.model", model)
-            chat_span.set_attribute("gen_ai.usage.input_tokens", random.randint(100, 500))
-            chat_span.set_attribute("gen_ai.usage.output_tokens", random.randint(50, 200))
-            chat_span.set_attribute("gen_ai.response.finish_reasons", ["tool_calls"])
+        with observe("events-reasoning", op=Op.CHAT):
+            enrich(
+                model=model,
+                provider=provider,
+                input_tokens=random.randint(100, 500),
+                output_tokens=random.randint(50, 200),
+                finish_reason="tool_calls",
+            )
             time.sleep(random.uniform(0.05, 0.15))
 
         # Check for fault injection
@@ -267,20 +265,16 @@ async def get_events(request: EventsRequest):
         # Tool execution via MCP server
         session_id = uuid4().hex
         request_id = uuid4().hex[:8]
-        with tracer.start_as_current_span(
-            "tools/call fetch_events_api",
-            kind=SpanKind.CLIENT,
-            attributes={
-                "mcp.method.name": "tools/call",
-                "mcp.session.id": session_id,
-                "mcp.protocol.version": MCP_PROTOCOL_VERSION,
-                "jsonrpc.request.id": request_id,
-                "gen_ai.operation.name": "execute_tool",
-                "gen_ai.tool.name": "fetch_events_api",
-                "network.transport": "tcp",
-                "network.protocol.name": "http",
-            },
-        ):
+
+        # MCP tool call — uses observe() for the span, with MCP-specific attributes set manually
+        with observe("fetch_events_api", op=Op.EXECUTE_TOOL, kind=SpanKind.CLIENT) as tool_span:
+            tool_span.set_attribute("mcp.method.name", "tools/call")
+            tool_span.set_attribute("mcp.session.id", session_id)
+            tool_span.set_attribute("mcp.protocol.version", MCP_PROTOCOL_VERSION)
+            tool_span.set_attribute("jsonrpc.request.id", request_id)
+            tool_span.set_attribute("network.transport", "tcp")
+            tool_span.set_attribute("network.protocol.name", "http")
+
             headers = {"mcp-session-id": session_id}
             inject(headers)
             payload = {
@@ -293,12 +287,15 @@ async def get_events(request: EventsRequest):
             events = [Event(name=e["name"], type=e["type"], venue=e.get("venue", "TBD"), date=e.get("date", date)) for e in events_list]
 
         span.set_attribute("events.count", len(events))
-        
-        root_span.set_attribute("gen_ai.output.messages", json.dumps(
-            [{"role": "assistant", "parts": [{"type": "text", "content": json.dumps([e.model_dump() for e in events])}]}]
-        ))
-        
-        return EventsResponse(destination=request.destination, events=events, agent_id=AGENT_ID)
+
+    # Set output on the parent HTTP request span. This enrich() is intentionally
+    # outside the observe() block — exiting observe() restores the parent span
+    # context, so enrich() here targets the HTTP request span, not the agent span.
+    enrich(
+        output_messages=[{"role": "assistant", "parts": [{"type": "text", "content": json.dumps([e.model_dump() for e in events])}]}],
+    )
+
+    return EventsResponse(destination=request.destination, events=events, agent_id=AGENT_ID)
 
 
 app = OpenTelemetryMiddleware(inner_app)

--- a/examples/plain-agents/multi-agent-planner/orchestrator/Dockerfile
+++ b/examples/plain-agents/multi-agent-planner/orchestrator/Dockerfile
@@ -7,8 +7,7 @@ RUN pip install --no-cache-dir \
     fastapi \
     uvicorn \
     httpx \
-    opentelemetry-api \
-    opentelemetry-sdk \
+    opensearch-genai-observability-sdk-py>=0.2.7 \
     opentelemetry-exporter-otlp-proto-grpc \
     opentelemetry-instrumentation-httpx \
     opentelemetry-instrumentation-asgi

--- a/examples/plain-agents/multi-agent-planner/orchestrator/main.py
+++ b/examples/plain-agents/multi-agent-planner/orchestrator/main.py
@@ -2,23 +2,23 @@
 """
 Travel Planner - Orchestrates weather and events agents.
 Supports fault injection at orchestrator level and pass-through to sub-agents.
+
+Instrumented with opensearch-genai-observability-sdk-py:
+- register() replaces ~20 lines of manual TracerProvider/exporter setup
+- observe() + enrich() replace manual span creation + set_attribute() calls
 """
 
 import asyncio
+import json
 import os
 import random
 import time
-import json
 from typing import Optional
-from uuid import uuid4
 
 import httpx
 from fastapi import FastAPI
 from opentelemetry import trace, metrics
-from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
 from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
 from opentelemetry.sdk.resources import Resource
@@ -26,6 +26,8 @@ from opentelemetry.trace import SpanKind, Status, StatusCode
 from opentelemetry.instrumentation.asgi import OpenTelemetryMiddleware
 from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
 from pydantic import BaseModel, Field
+
+from opensearch_genai_observability_sdk_py import Op, enrich, observe, register
 
 
 AGENT_ID = "travel-planner-001"
@@ -99,30 +101,29 @@ class PlanResponse(BaseModel):
     errors: list = []
 
 
-def setup_telemetry(service_name: str, otlp_endpoint: str):
-    resource = Resource.create({
-        "service.name": service_name,
-        "service.version": "1.0.0",
-        "gen_ai.agent.id": AGENT_ID,
-        "gen_ai.agent.name": AGENT_NAME,
-    })
-    tracer_provider = TracerProvider(resource=resource)
-    tracer_provider.add_span_processor(
-        BatchSpanProcessor(OTLPSpanExporter(endpoint=otlp_endpoint, insecure=True))
-    )
-    trace.set_tracer_provider(tracer_provider)
-    HTTPXClientInstrumentor().instrument()
-    metric_reader = PeriodicExportingMetricReader(
-        OTLPMetricExporter(endpoint=otlp_endpoint, insecure=True),
-        export_interval_millis=10000,
-    )
-    meter_provider = MeterProvider(resource=resource, metric_readers=[metric_reader])
-    metrics.set_meter_provider(meter_provider)
-    return trace.get_tracer(service_name), metrics.get_meter(service_name)
-
-
+# --- Telemetry setup ---
+# SDK handles tracing; metrics still need manual setup
 otlp_endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
-tracer, meter = setup_telemetry("travel-planner", otlp_endpoint)
+
+# One line replaces ~20 lines of TracerProvider + exporter setup
+register(
+    endpoint=f"grpc://{otlp_endpoint.replace('http://', '').replace('https://', '')}",
+    service_name="travel-planner",
+    service_version="1.0.0",
+)
+
+# Metrics (SDK handles tracing only)
+# TODO: unify Resource with register() when SDK supports metrics
+resource = Resource.create({"service.name": "travel-planner"})
+metric_reader = PeriodicExportingMetricReader(
+    OTLPMetricExporter(endpoint=otlp_endpoint, insecure=True),
+    export_interval_millis=10000,
+)
+meter_provider = MeterProvider(resource=resource, metric_readers=[metric_reader])
+metrics.set_meter_provider(meter_provider)
+
+# HTTPx auto-instrumentation for outbound calls
+HTTPXClientInstrumentor().instrument()
 
 
 inner_app = FastAPI(title="Travel Planner", version="1.0.0")
@@ -136,45 +137,43 @@ async def health():
 @inner_app.post("/plan")
 async def plan_trip(request: PlanRequest):
     model = random.choice(MODELS)
-    
+    provider = SYSTEMS[model]
+
     # Promote gen_ai attributes to the root HTTP span so the UI can read them
+    enrich(
+        model=model,
+        provider=provider,
+        agent_id=AGENT_ID,
+        input_messages=[{"role": "user", "parts": [{"type": "text", "content": f"Plan a trip to {request.destination}"}]}],
+    )
+    # Set agent name and operation on the root span directly
     root_span = trace.get_current_span()
-    root_span.set_attribute("gen_ai.system", SYSTEMS[model])
     root_span.set_attribute("gen_ai.agent.name", AGENT_NAME)
-    root_span.set_attribute("gen_ai.request.model", model)
     root_span.set_attribute("gen_ai.operation.name", "invoke_agent")
-    root_span.set_attribute("gen_ai.input.messages", json.dumps(
-        [{"role": "user", "parts": [{"type": "text", "content": f"Plan a trip to {request.destination}"}]}]
-    ))
-    
-    with tracer.start_as_current_span(
-        "invoke_agent",
-        kind=SpanKind.INTERNAL,
-        attributes={
-            "gen_ai.operation.name": "invoke_agent",
-            "gen_ai.agent.id": AGENT_ID,
-            "gen_ai.agent.name": AGENT_NAME,
-            "gen_ai.system": SYSTEMS[model],
-            "gen_ai.request.model": model,
-            "gen_ai.tool.definitions": json.dumps(TOOL_DEFINITIONS),
-            "destination": request.destination,
-        },
-    ) as span:
+
+    with observe(AGENT_NAME, op=Op.INVOKE_AGENT) as span:
+        enrich(
+            model=model,
+            provider=provider,
+            agent_id=AGENT_ID,
+            tool_definitions=TOOL_DEFINITIONS,
+            destination=request.destination,
+        )
+
         fault = request.fault
         errors = []
         weather_data = None
         events_data = []
 
         # Synthetic "thinking" LLM call
-        with tracer.start_as_current_span("chat", kind=SpanKind.INTERNAL) as chat_span:
-            chat_span.set_attribute("gen_ai.operation.name", "chat")
-            chat_span.set_attribute("gen_ai.system", SYSTEMS[model])
-            chat_span.set_attribute("gen_ai.request.model", model)
-            input_tokens = random.randint(500, 2000)
-            output_tokens = random.randint(100, 500)
-            chat_span.set_attribute("gen_ai.usage.input_tokens", input_tokens)
-            chat_span.set_attribute("gen_ai.usage.output_tokens", output_tokens)
-            chat_span.set_attribute("gen_ai.response.finish_reasons", ["tool_calls"])
+        with observe("planning", op=Op.CHAT):
+            enrich(
+                model=model,
+                provider=provider,
+                input_tokens=random.randint(500, 2000),
+                output_tokens=random.randint(100, 500),
+                finish_reason="tool_calls",
+            )
             time.sleep(random.uniform(0.1, 0.3))
 
         # Build sub-agent payloads with fault pass-through
@@ -190,19 +189,14 @@ async def plan_trip(request: PlanRequest):
         # Orchestrator-level fault injection
         if fault and fault.orchestrator:
             span.set_attribute("fault.orchestrator", fault.orchestrator)
-
-            if fault.orchestrator == "fan_out_timeout":
-                timeout = 0.001
-            else:
-                timeout = 30.0
+            timeout = 0.001 if fault.orchestrator == "fan_out_timeout" else 30.0
         else:
             timeout = 30.0
 
         # Fan out to sub-agents
         async with httpx.AsyncClient(timeout=timeout) as client:
             # Invoke weather agent
-            with tracer.start_as_current_span("invoke_agent weather-agent", kind=SpanKind.CLIENT) as agent_span:
-                agent_span.set_attribute("gen_ai.operation.name", "invoke_agent")
+            with observe("weather-agent", op=Op.INVOKE_AGENT, kind=SpanKind.CLIENT) as agent_span:
                 agent_span.set_attribute("gen_ai.agent.name", "weather-agent")
                 try:
                     if fault and fault.orchestrator == "partial_failure" and random.random() < 0.5:
@@ -218,8 +212,7 @@ async def plan_trip(request: PlanRequest):
                     agent_span.set_status(Status(StatusCode.ERROR, str(e)))
 
             # Invoke events agent
-            with tracer.start_as_current_span("invoke_agent events-agent", kind=SpanKind.CLIENT) as agent_span:
-                agent_span.set_attribute("gen_ai.operation.name", "invoke_agent")
+            with observe("events-agent", op=Op.INVOKE_AGENT, kind=SpanKind.CLIENT) as agent_span:
                 agent_span.set_attribute("gen_ai.agent.name", "events-agent")
                 try:
                     if fault and fault.orchestrator == "partial_failure" and random.random() < 0.5:
@@ -237,16 +230,17 @@ async def plan_trip(request: PlanRequest):
                         agent_span.set_status(Status(StatusCode.ERROR, resp.text))
                 except Exception as e:
                     errors.append({"agent": "events", "error": str(e)})
-                    tool_span.set_status(Status(StatusCode.ERROR, str(e)))
+                    agent_span.set_status(Status(StatusCode.ERROR, str(e)))
 
         # Final response "chat" span
-        with tracer.start_as_current_span("chat", kind=SpanKind.INTERNAL) as chat_span:
-            chat_span.set_attribute("gen_ai.operation.name", "chat")
-            chat_span.set_attribute("gen_ai.system", SYSTEMS[model])
-            chat_span.set_attribute("gen_ai.request.model", model)
-            chat_span.set_attribute("gen_ai.usage.input_tokens", random.randint(200, 800))
-            chat_span.set_attribute("gen_ai.usage.output_tokens", random.randint(50, 200))
-            chat_span.set_attribute("gen_ai.response.finish_reasons", ["stop"])
+        with observe("summarize", op=Op.CHAT):
+            enrich(
+                model=model,
+                provider=provider,
+                input_tokens=random.randint(200, 800),
+                output_tokens=random.randint(50, 200),
+                finish_reason="stop",
+            )
             time.sleep(random.uniform(0.05, 0.15))
 
         # Build recommendation with graceful degradation
@@ -261,18 +255,21 @@ async def plan_trip(request: PlanRequest):
 
         recommendation = build_recommendation(request.destination, weather_data, events_data, partial)
 
-        root_span.set_attribute("gen_ai.output.messages", json.dumps(
-            [{"role": "assistant", "parts": [{"type": "text", "content": recommendation}]}]
-        ))
+    # Set output on the parent HTTP request span. This enrich() is intentionally
+    # outside the observe() block — exiting observe() restores the parent span
+    # context, so enrich() here targets the HTTP request span, not the agent span.
+    enrich(
+        output_messages=[{"role": "assistant", "parts": [{"type": "text", "content": recommendation}]}],
+    )
 
-        return PlanResponse(
-            destination=request.destination,
-            weather=weather_data,
-            events=events_data,
-            recommendation=recommendation,
-            partial=partial,
-            errors=errors,
-        )
+    return PlanResponse(
+        destination=request.destination,
+        weather=weather_data,
+        events=events_data,
+        recommendation=recommendation,
+        partial=partial,
+        errors=errors,
+    )
 
 
 def build_recommendation(destination: str, weather: Optional[dict], events: list, partial: bool) -> str:

--- a/examples/plain-agents/weather-agent/Dockerfile
+++ b/examples/plain-agents/weather-agent/Dockerfile
@@ -10,8 +10,7 @@ RUN pip install --no-cache-dir \
     fastapi \
     uvicorn \
     httpx \
-    opentelemetry-api \
-    opentelemetry-sdk \
+    opensearch-genai-observability-sdk-py>=0.2.7 \
     opentelemetry-exporter-otlp-proto-grpc \
     opentelemetry-instrumentation-asgi
 

--- a/examples/plain-agents/weather-agent/main.py
+++ b/examples/plain-agents/weather-agent/main.py
@@ -2,8 +2,9 @@
 """
 Weather Agent Example - OpenTelemetry Instrumentation
 
-This example demonstrates how to instrument an AI agent application with OpenTelemetry
-to send telemetry data to the Observability Stack using OTLP protocol.
+Instrumented with opensearch-genai-observability-sdk-py:
+- register() replaces ~30 lines of manual TracerProvider/exporter setup
+- @observe decorator + enrich() replace manual span creation + set_attribute() calls
 
 Key features demonstrated:
 - OTLP exporter configuration for traces, metrics, and logs
@@ -11,14 +12,6 @@ Key features demonstrated:
 - Structured content capture (system instructions, messages, tool calls)
 - Token usage metrics
 - Structured logging with trace correlation
-
-References:
-- OpenTelemetry GenAI Semantic Conventions:
-  https://github.com/open-telemetry/semantic-conventions/tree/e126ea9105b15912ccd80deab98929025189b696/docs/gen-ai
-- Agent spans: gen-ai-agent-spans.md
-- Tool execution: gen-ai-spans.md#execute-tool-span
-- Input/output message schemas: gen-ai-input-messages.json, gen-ai-output-messages.json
-- System instructions schema: gen-ai-system-instructions.json
 """
 
 from dataclasses import dataclass
@@ -29,22 +22,21 @@ import random
 import time
 from typing import Dict, Any, List, Optional
 from uuid import uuid4
+
 import httpx
 from opentelemetry import trace, metrics
-from opentelemetry.trace import SpanKind
+from opentelemetry.trace import SpanKind, Status, StatusCode
 from opentelemetry.propagate import inject
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
 from opentelemetry.sdk.resources import Resource
-from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
 from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
 from opentelemetry._logs import set_logger_provider
 from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
 from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
 from opentelemetry.exporter.otlp.proto.grpc._log_exporter import OTLPLogExporter
-from opentelemetry.trace import Status, StatusCode
+
+from opensearch_genai_observability_sdk_py import Op, enrich, observe, register
 
 
 # Fault injection exceptions
@@ -98,59 +90,50 @@ SYSTEMS = {
 }
 
 
-# Configure OpenTelemetry with OTLP exporters
 def setup_telemetry(
     service_name: str = "weather-agent",
     service_version: str = "1.0.0",
     otlp_endpoint: str = "http://localhost:4317"
 ) -> tuple:
     """
-    Set up OpenTelemetry with OTLP exporters for traces, metrics, and logs.
-    
-    Args:
-        service_name: Name of the service/agent
-        service_version: Version of the service
-        otlp_endpoint: OTLP collector endpoint (gRPC)
-    
-    Returns:
-        Tuple of (tracer, meter, logger)
+    Set up telemetry using the SDK for tracing, plus manual setup for metrics and logs.
+
+    The SDK's register() replaces ~30 lines of TracerProvider/exporter config.
+    Metrics and logs still use manual OTel setup (SDK handles tracing only).
     """
-    # Create resource with service information
+    # Tracing — one line via SDK
+    register(
+        endpoint=f"grpc://{otlp_endpoint.replace('http://', '').replace('https://', '')}",
+        service_name=service_name,
+        service_version=service_version,
+    )
+
+    # Metrics — manual setup (SDK handles tracing only)
+    # TODO: unify Resource with register() when SDK supports metrics
     resource = Resource.create({
         "service.name": service_name,
         "service.version": service_version,
         "deployment.environment": "development"
     })
-    
-    # Set up tracing
-    trace_provider = TracerProvider(resource=resource)
-    otlp_trace_exporter = OTLPSpanExporter(endpoint=otlp_endpoint, insecure=True)
-    trace_provider.add_span_processor(BatchSpanProcessor(otlp_trace_exporter))
-    trace.set_tracer_provider(trace_provider)
-    tracer = trace.get_tracer(__name__)
-    
-    # Set up metrics
     otlp_metric_exporter = OTLPMetricExporter(endpoint=otlp_endpoint, insecure=True)
-    # Export metrics every 2 seconds for faster demo feedback
     metric_reader = PeriodicExportingMetricReader(otlp_metric_exporter, export_interval_millis=2000)
     meter_provider = MeterProvider(resource=resource, metric_readers=[metric_reader])
     metrics.set_meter_provider(meter_provider)
     meter = metrics.get_meter(__name__)
-    
-    # Set up logging
+
+    # Logging — manual setup
     logger_provider = LoggerProvider(resource=resource)
     otlp_log_exporter = OTLPLogExporter(endpoint=otlp_endpoint, insecure=True)
     logger_provider.add_log_record_processor(BatchLogRecordProcessor(otlp_log_exporter))
     set_logger_provider(logger_provider)
-    
-    # Configure Python logging to use OpenTelemetry
+
     handler = LoggingHandler(level=logging.INFO, logger_provider=logger_provider)
     logging.getLogger().addHandler(handler)
     logging.getLogger().setLevel(logging.INFO)
-    
+
     logger = logging.getLogger(__name__)
-    
-    return tracer, meter, logger
+
+    return meter, logger
 
 
 # MCP Server configuration
@@ -160,19 +143,8 @@ MCP_PROTOCOL_VERSION = "2025-06-18"
 
 # Simulated weather tool
 def get_weather(location: str) -> Dict[str, Any]:
-    """
-    Simulated weather API call.
-    
-    Args:
-        location: Location to get weather for
-    
-    Returns:
-        Weather data dictionary
-    """
-    # Simulate API latency
+    """Simulated weather API call."""
     time.sleep(0.5)
-    
-    # Return mock weather data
     return {
         "location": location,
         "temperature": "57°F",
@@ -216,15 +188,12 @@ def call_llm(
     messages: List[Dict[str, str]],
     tools: List[Dict[str, Any]]
 ) -> Dict[str, Any]:
-    """
-    Simulated LLM API call that selects appropriate tool based on query.
-    """
+    """Simulated LLM API call that selects appropriate tool based on query."""
     time.sleep(1.0)
-    
+
     user_message = messages[-1]["content"].lower()
     location = messages[-1]["content"].split()[-1].rstrip("?")
-    
-    # Determine which tool to call based on query
+
     if any(word in user_message for word in ["forecast", "next", "tomorrow", "week", "upcoming"]):
         tool_name = "get_forecast"
         arguments = {"location": location, "days": 3}
@@ -234,7 +203,7 @@ def call_llm(
     else:
         tool_name = "get_current_weather"
         arguments = {"location": location}
-    
+
     return {
         "id": "chatcmpl-123456",
         "model": "gpt-4-0613",
@@ -262,40 +231,34 @@ def call_llm(
 
 class WeatherAgent:
     """
-    Example AI agent that answers weather questions using OpenTelemetry instrumentation.
-    
-    This agent demonstrates:
-    - invoke_agent spans for agent invocations
-    - execute_tool spans for tool executions
-    - Gen-AI semantic convention attributes
-    - Custom agent context attributes
-    - Structured logging with trace correlation
+    AI agent that answers weather questions, instrumented with the GenAI observability SDK.
+
+    Uses @observe decorator and enrich() instead of manual span creation and set_attribute() calls.
     """
-    
-    def __init__(self, tracer, meter, logger):
-        self.tracer = tracer
+
+    def __init__(self, meter, logger):
         self.meter = meter
         self.logger = logger
-        
+
         # Agent metadata
         self.agent_id = "asst_weather_001"
         self.agent_name = "Weather Assistant"
         self.agent_description = "Helps users get weather information for any location"
-        self.model = random.choice(MODELS)  # Rotate model per instance
-        
+        self.model = random.choice(MODELS)
+
         # Create metrics
         self.token_counter = meter.create_counter(
             name="gen_ai.client.token.usage",
             description="Number of tokens used in LLM operations",
             unit="token"
         )
-        
+
         self.operation_duration = meter.create_histogram(
             name="gen_ai.client.operation.duration",
             description="Duration of agent operations",
             unit="s"
         )
-        
+
         # Available tools
         self.tools = [
             {
@@ -343,9 +306,8 @@ class WeatherAgent:
                 }
             }
         ]
-    
+
     def _should_inject_fault(self, fault: Optional[FaultConfig]) -> bool:
-        """Check if fault should be injected based on probability."""
         if fault is None:
             return False
         return random.random() < fault.probability
@@ -353,55 +315,41 @@ class WeatherAgent:
     def invoke(self, user_message: str, conversation_id: str, fault: Optional[FaultConfig] = None) -> str:
         """
         Invoke the agent with a user message.
-        
-        This method creates an invoke_agent span following gen-ai semantic conventions.
-        
-        Args:
-            user_message: User's question
-            conversation_id: Conversation/session identifier
-            fault: Optional fault injection configuration
-        
-        Returns:
-            Agent's response
+
+        Uses observe() context manager + enrich() instead of manual span creation.
         """
         start_time = time.time()
-        
-        # System instructions (separate from chat history per spec)
+        provider = SYSTEMS.get(self.model, "openai")
+
         system_instructions = [
             {"type": "text", "content": "You are a helpful weather assistant."}
         ]
-        
-        # Create invoke_agent span with gen-ai semantic conventions
-        with self.tracer.start_as_current_span(
-            f"invoke_agent {self.agent_name}",
-            kind=trace.SpanKind.CLIENT
-        ) as span:
+
+        input_messages = [
+            {"role": "user", "parts": [{"type": "text", "content": user_message}]}
+        ]
+
+        # Create invoke_agent span with observe() + enrich()
+        with observe(self.agent_name, op=Op.INVOKE_AGENT, kind=SpanKind.CLIENT) as span:
             try:
-                # Required attributes
-                span.set_attribute("gen_ai.operation.name", "invoke_agent")
-                span.set_attribute("gen_ai.provider.name", SYSTEMS.get(self.model, "openai"))
-                span.set_attribute("gen_ai.system", SYSTEMS.get(self.model, "openai"))
-                
-                # Conditionally required attributes
-                span.set_attribute("gen_ai.agent.id", self.agent_id)
-                span.set_attribute("gen_ai.agent.name", self.agent_name)
-                span.set_attribute("gen_ai.agent.description", self.agent_description)
-                span.set_attribute("gen_ai.conversation.id", conversation_id)
-                span.set_attribute("gen_ai.request.model", self.model)
+                # enrich() sets all gen_ai.* attributes in one call
+                enrich(
+                    model=self.model,
+                    provider=provider,
+                    agent_id=self.agent_id,
+                    agent_description=self.agent_description,
+                    session_id=conversation_id,
+                    temperature=0.7,
+                    max_tokens=1024,
+                    system_instructions=json.dumps(system_instructions),
+                    tool_definitions=self.tools,
+                    input_messages=input_messages,
+                )
+                # Extra attributes not covered by enrich()
                 span.set_attribute("gen_ai.output.type", "text")
-                
-                # Recommended attributes
-                span.set_attribute("gen_ai.request.temperature", 0.7)
-                span.set_attribute("gen_ai.request.max_tokens", 1024)
                 span.set_attribute("server.address", "api.openai.com")
                 span.set_attribute("server.port", 443)
-                
-                # Opt-in attributes (content capture)
-                # See schema definitions: https://github.com/open-telemetry/semantic-conventions/tree/e126ea9105b15912ccd80deab98929025189b696/docs/gen-ai
-                span.set_attribute("gen_ai.system_instructions", json.dumps(system_instructions))
-                span.set_attribute("gen_ai.tool.definitions", json.dumps(self.tools))
-                
-                # Structured logging with trace correlation
+
                 self.logger.info(
                     "Agent invoked",
                     extra={
@@ -412,71 +360,61 @@ class WeatherAgent:
                         "user_message": user_message
                     }
                 )
-                
-                # Prepare input messages following gen-ai-input-messages.json schema
-                # See: https://github.com/open-telemetry/semantic-conventions/tree/e126ea9105b15912ccd80deab98929025189b696/docs/gen-ai
-                input_messages = [
-                    {
-                        "role": "user",
-                        "parts": [{"type": "text", "content": user_message}]
-                    }
-                ]
-                
-                # Opt-in: Record input messages as attribute
-                span.set_attribute("gen_ai.input.messages", json.dumps(input_messages))
-                
+
                 # Check for pre-LLM faults
                 if self._should_inject_fault(fault):
                     if fault.delay_ms:
                         time.sleep(fault.delay_ms / 1000)
-                    
+
                     if fault.type == "rate_limited":
                         span.set_status(Status(StatusCode.ERROR, "Rate limit exceeded"))
                         span.set_attribute("error.type", "rate_limit_exceeded")
                         raise RateLimitError("Rate limit exceeded. Retry after 60 seconds.")
-                    
+
                     if fault.type == "hallucination":
-                        # Skip tool call, return fabricated response
-                        hallucinated_response = f"The weather is 22°C and sunny with light winds."
+                        hallucinated_response = "The weather is 22°C and sunny with light winds."
+                        enrich(
+                            response_id=f"chatcmpl-hallucinated-{conversation_id[:8]}",
+                            finish_reason="stop",
+                            input_tokens=50,
+                            output_tokens=20,
+                            output_messages=[{"role": "assistant", "parts": [{"type": "text", "content": hallucinated_response}], "finish_reason": "stop"}],
+                        )
                         span.set_attribute("gen_ai.response.model", self.model)
-                        span.set_attribute("gen_ai.response.id", f"chatcmpl-hallucinated-{conversation_id[:8]}")
-                        span.set_attribute("gen_ai.response.finish_reasons", ["stop"])
-                        span.set_attribute("gen_ai.usage.input_tokens", 50)
-                        span.set_attribute("gen_ai.usage.output_tokens", 20)
-                        output_messages = [{"role": "assistant", "parts": [{"type": "text", "content": hallucinated_response}], "finish_reason": "stop"}]
-                        span.set_attribute("gen_ai.output.messages", json.dumps(output_messages))
                         span.set_status(Status(StatusCode.OK))
                         return hallucinated_response
-                
-                # Prepare messages for LLM call (internal format)
+
+                # Prepare messages for LLM call
                 messages = [
                     {"role": "system", "content": system_instructions[0]["content"]},
                     {"role": "user", "content": user_message}
                 ]
-                
-                # Call LLM
+
                 llm_response = call_llm(self.model, messages, self.tools)
-                
-                # Check for token_limit_exceeded fault (simulates truncated response)
+
+                # Check for token_limit_exceeded fault
                 if self._should_inject_fault(fault) and fault.type == "token_limit_exceeded":
+                    enrich(
+                        response_id=llm_response["id"],
+                        finish_reason="length",
+                        input_tokens=llm_response["usage"]["prompt_tokens"],
+                        output_tokens=1024,
+                    )
                     span.set_attribute("gen_ai.response.model", llm_response["model"])
-                    span.set_attribute("gen_ai.response.id", llm_response["id"])
-                    span.set_attribute("gen_ai.response.finish_reasons", ["length"])
-                    span.set_attribute("gen_ai.usage.input_tokens", llm_response["usage"]["prompt_tokens"])
-                    span.set_attribute("gen_ai.usage.output_tokens", 1024)  # Hit limit
                     truncated_response = "The weather in the requested location is currently showing temperatures around—"
-                    output_messages = [{"role": "assistant", "parts": [{"type": "text", "content": truncated_response}], "finish_reason": "length"}]
-                    span.set_attribute("gen_ai.output.messages", json.dumps(output_messages))
+                    enrich(output_messages=[{"role": "assistant", "parts": [{"type": "text", "content": truncated_response}], "finish_reason": "length"}])
                     span.set_status(Status(StatusCode.OK))
                     return truncated_response
-                
-                # Recommended response attributes
+
+                # Set response attributes via enrich()
+                enrich(
+                    response_id=llm_response["id"],
+                    finish_reason=llm_response["choices"][0]["finish_reason"],
+                    input_tokens=llm_response["usage"]["prompt_tokens"],
+                    output_tokens=llm_response["usage"]["completion_tokens"],
+                )
                 span.set_attribute("gen_ai.response.model", llm_response["model"])
-                span.set_attribute("gen_ai.response.id", llm_response["id"])
-                span.set_attribute("gen_ai.response.finish_reasons", [llm_response["choices"][0]["finish_reason"]])
-                span.set_attribute("gen_ai.usage.input_tokens", llm_response["usage"]["prompt_tokens"])
-                span.set_attribute("gen_ai.usage.output_tokens", llm_response["usage"]["completion_tokens"])
-                
+
                 # Record token usage metrics
                 self.token_counter.add(
                     llm_response["usage"]["prompt_tokens"],
@@ -489,7 +427,6 @@ class WeatherAgent:
                         "server.address": "api.openai.com"
                     }
                 )
-                
                 self.token_counter.add(
                     llm_response["usage"]["completion_tokens"],
                     attributes={
@@ -501,26 +438,24 @@ class WeatherAgent:
                         "server.address": "api.openai.com"
                     }
                 )
-                
+
                 # Execute tool if requested
                 tool_call = llm_response["choices"][0]["message"].get("tool_calls", [None])[0]
                 tool_call_id = tool_call["id"] if tool_call else None
-                
+
                 if tool_call:
                     tool_name = tool_call["function"]["name"]
                     tool_args = json.loads(tool_call["function"]["arguments"])
-                    
+
                     # wrong_tool fault: swap the tool being called
                     if self._should_inject_fault(fault) and fault.type == "wrong_tool":
                         wrong_tools = {"get_current_weather": "get_forecast", "get_forecast": "get_historical_weather", "get_historical_weather": "get_current_weather"}
                         tool_name = wrong_tools.get(tool_name, tool_name)
-                        # Adjust args for the wrong tool
                         if tool_name == "get_historical_weather":
                             tool_args["date"] = "2026-01-25"
-                    
-                    # Pass fault config to execute_tool for tool-specific faults
+
                     tool_result = self.execute_tool(tool_name, tool_args, tool_call_id, fault)
-                    
+
                     # Generate final response based on tool result
                     if "temperature" in tool_result:
                         final_response = f"The weather in {tool_result['location']} is {tool_result['condition']} with a temperature of {tool_result['temperature']}."
@@ -533,19 +468,12 @@ class WeatherAgent:
                         final_response = f"Weather data for {tool_result.get('location', 'unknown')}: {tool_result}"
                 else:
                     final_response = "I couldn't determine what you're asking about."
-                
-                # Opt-in: Record output messages following gen-ai-output-messages.json schema
-                # See: https://github.com/open-telemetry/semantic-conventions/tree/e126ea9105b15912ccd80deab98929025189b696/docs/gen-ai
-                output_messages = [
-                    {
-                        "role": "assistant",
-                        "parts": [{"type": "text", "content": final_response}],
-                        "finish_reason": "stop"
-                    }
-                ]
-                span.set_attribute("gen_ai.output.messages", json.dumps(output_messages))
-                
-                # Log successful completion
+
+                # Record output messages via enrich()
+                enrich(output_messages=[
+                    {"role": "assistant", "parts": [{"type": "text", "content": final_response}], "finish_reason": "stop"}
+                ])
+
                 self.logger.info(
                     "Agent invocation completed",
                     extra={
@@ -556,8 +484,7 @@ class WeatherAgent:
                         "response": final_response
                     }
                 )
-                
-                # Record operation duration
+
                 duration = time.time() - start_time
                 self.operation_duration.record(
                     duration,
@@ -569,12 +496,11 @@ class WeatherAgent:
                         "server.address": "api.openai.com"
                     }
                 )
-                
+
                 span.set_status(Status(StatusCode.OK))
                 return final_response
-                
+
             except Exception as e:
-                # Log error
                 self.logger.error(
                     f"Agent invocation failed: {str(e)}",
                     extra={
@@ -588,26 +514,24 @@ class WeatherAgent:
                 span.set_status(Status(StatusCode.ERROR, str(e)))
                 span.record_exception(e)
                 raise
-    
+
     def _call_mcp_tool(self, tool_name: str, arguments: dict, session_id: str) -> dict:
         """Call MCP server with proper CLIENT span and trace propagation."""
         request_id = uuid4().hex[:8]
-        with self.tracer.start_as_current_span(
-            f"tools/call {tool_name}",
-            kind=SpanKind.CLIENT,
-            attributes={
-                "mcp.method.name": "tools/call",
-                "mcp.session.id": session_id,
-                "mcp.protocol.version": MCP_PROTOCOL_VERSION,
-                "jsonrpc.request.id": request_id,
-                "gen_ai.operation.name": "execute_tool",
-                "gen_ai.tool.name": tool_name,
-                "network.transport": "tcp",
-                "network.protocol.name": "http",
-            },
-        ):
+
+        # Use observe() for the MCP span, with MCP-specific attributes set manually
+        with observe(f"tools/call {tool_name}", kind=SpanKind.CLIENT) as span:
+            span.set_attribute("mcp.method.name", "tools/call")
+            span.set_attribute("mcp.session.id", session_id)
+            span.set_attribute("mcp.protocol.version", MCP_PROTOCOL_VERSION)
+            span.set_attribute("jsonrpc.request.id", request_id)
+            span.set_attribute("gen_ai.operation.name", "execute_tool")
+            span.set_attribute("gen_ai.tool.name", tool_name)
+            span.set_attribute("network.transport", "tcp")
+            span.set_attribute("network.protocol.name", "http")
+
             headers = {"mcp-session-id": session_id}
-            inject(headers)  # Propagate trace context
+            inject(headers)
             payload = {
                 "jsonrpc": "2.0", "method": "tools/call", "id": request_id,
                 "params": {"name": tool_name, "arguments": arguments}
@@ -621,27 +545,21 @@ class WeatherAgent:
     def execute_tool(self, tool_name: str, arguments: Dict[str, Any], tool_call_id: str = None, fault: Optional[FaultConfig] = None) -> Dict[str, Any]:
         """
         Execute a tool with proper instrumentation.
-        
-        This method creates an execute_tool span following gen-ai semantic conventions.
-        For weather tools, delegates to MCP server for actual execution.
+
+        Uses observe() context manager + enrich() for the execute_tool span.
         """
-        # Create execute_tool span with gen-ai semantic conventions
-        with self.tracer.start_as_current_span(
-            f"execute_tool {tool_name}",
-            kind=trace.SpanKind.INTERNAL
-        ) as span:
+        with observe(tool_name, op=Op.EXECUTE_TOOL) as span:
             try:
-                span.set_attribute("gen_ai.operation.name", "execute_tool")
-                span.set_attribute("gen_ai.tool.name", tool_name)
+                # Set tool-specific attributes
                 span.set_attribute("gen_ai.tool.type", "function")
                 if tool_call_id:
                     span.set_attribute("gen_ai.tool.call.id", tool_call_id)
-                
+
                 tool_def = next((t for t in self.tools if t["function"]["name"] == tool_name), None)
                 if tool_def:
                     span.set_attribute("gen_ai.tool.description", tool_def["function"]["description"])
                 span.set_attribute("gen_ai.tool.call.arguments", json.dumps(arguments))
-                
+
                 # Check for fault injection
                 if self._should_inject_fault(fault) and fault.type in ("tool_timeout", "tool_error", "high_latency"):
                     target_tool = fault.tool or tool_name
@@ -654,32 +572,30 @@ class WeatherAgent:
                         if fault.type == "tool_error":
                             span.set_status(Status(StatusCode.ERROR, "Tool execution failed"))
                             raise ToolExecutionError(f"Tool '{tool_name}' failed: External API returned 503")
-                
+
                 self.logger.info(f"Executing tool: {tool_name}")
-                
+
                 # Route to MCP server for weather API calls, local for others
                 session_id = uuid4().hex
                 if tool_name in ("get_current_weather", "get_weather"):
                     result = self._call_mcp_tool("fetch_weather_api", {"location": arguments["location"]}, session_id)
                 elif tool_name == "get_forecast":
-                    # Local tool - no MCP
-                    with self.tracer.start_as_current_span(f"local_tool {tool_name}", kind=trace.SpanKind.INTERNAL) as local_span:
+                    with observe(f"local_tool {tool_name}") as local_span:
                         local_span.set_attribute("gen_ai.tool.name", tool_name)
                         local_span.set_attribute("tool.source", "local")
                         result = get_forecast(arguments["location"], arguments.get("days", 3))
                 elif tool_name == "get_historical_weather":
-                    # Local tool - no MCP
-                    with self.tracer.start_as_current_span(f"local_tool {tool_name}", kind=trace.SpanKind.INTERNAL) as local_span:
+                    with observe(f"local_tool {tool_name}") as local_span:
                         local_span.set_attribute("gen_ai.tool.name", tool_name)
                         local_span.set_attribute("tool.source", "local")
                         result = get_historical_weather(arguments["location"], arguments.get("date", "2026-01-01"))
                 else:
                     raise ValueError(f"Unknown tool: {tool_name}")
-                
+
                 span.set_attribute("gen_ai.tool.call.result", json.dumps(result))
                 span.set_status(Status(StatusCode.OK))
                 return result
-                
+
             except Exception as e:
                 self.logger.error(f"Tool execution failed: {tool_name} - {str(e)}")
                 span.set_attribute("error.type", type(e).__name__)
@@ -689,49 +605,41 @@ class WeatherAgent:
 
 
 def main():
-    """
-    Main function demonstrating agent usage with OpenTelemetry instrumentation.
-    """
-    print("Weather Agent Example - OpenTelemetry Instrumentation")
+    """Main function demonstrating agent usage with SDK instrumentation."""
+    print("Weather Agent Example - SDK Instrumentation")
     print("=" * 60)
     print()
-    
-    # Set up OpenTelemetry
-    print("Setting up OpenTelemetry with OTLP exporters...")
-    tracer, meter, logger = setup_telemetry(
+
+    print("Setting up telemetry (SDK + metrics + logs)...")
+    meter, logger = setup_telemetry(
         service_name="weather-agent",
         service_version="1.0.0",
         otlp_endpoint="http://localhost:4317"
     )
-    print("✓ OpenTelemetry configured")
+    print("Telemetry configured")
     print()
-    
-    # Create agent
+
     print("Creating Weather Agent...")
-    agent = WeatherAgent(tracer, meter, logger)
-    print(f"✓ Agent created: {agent.agent_name} (ID: {agent.agent_id})")
+    agent = WeatherAgent(meter, logger)
+    print(f"Agent created: {agent.agent_name} (ID: {agent.agent_id})")
     print()
-    
-    # Example conversation
+
     conversation_id = "conv_example_001"
     user_message = "What's the weather in Paris?"
-    
+
     print(f"User: {user_message}")
     print()
-    
-    # Invoke agent
+
     print("Invoking agent...")
     response = agent.invoke(user_message, conversation_id)
     print(f"Agent: {response}")
     print()
-    
-    # Give time for telemetry to be exported
-    # Metrics export every 2 seconds, so wait at least 3 seconds
+
     print("Waiting for telemetry export...")
     time.sleep(3)
-    print("✓ Telemetry exported to Observability Stack")
+    print("Telemetry exported to Observability Stack")
     print()
-    
+
     print("=" * 60)
     print("Example complete!")
     print()

--- a/examples/plain-agents/weather-agent/pyproject.toml
+++ b/examples/plain-agents/weather-agent/pyproject.toml
@@ -5,8 +5,7 @@ description = "Plain Python weather agent with OpenTelemetry instrumentation for
 readme = "README.md"
 requires-python = ">=3.9"
 dependencies = [
-    "opentelemetry-api>=1.20.0",
-    "opentelemetry-sdk>=1.20.0",
+    "opensearch-genai-observability-sdk-py>=0.2.7",
     "opentelemetry-exporter-otlp-proto-grpc>=1.20.0",
     "fastapi>=0.104.0",
     "uvicorn>=0.24.0",

--- a/examples/plain-agents/weather-agent/server.py
+++ b/examples/plain-agents/weather-agent/server.py
@@ -17,6 +17,8 @@ from pydantic import BaseModel, Field
 from opentelemetry import trace as trace_api
 from opentelemetry.instrumentation.asgi import OpenTelemetryMiddleware
 
+from opensearch_genai_observability_sdk_py import enrich
+
 from main import WeatherAgent, setup_telemetry, FaultConfig, AgentError, SYSTEMS
 
 
@@ -47,14 +49,14 @@ class HealthResponse(BaseModel):
 
 # Setup telemetry BEFORE creating app
 otlp_endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
-tracer, meter, logger = setup_telemetry(
+meter, logger = setup_telemetry(
     service_name="weather-agent",
     service_version="1.0.0",
     otlp_endpoint=otlp_endpoint,
 )
 
 # Create agent
-agent = WeatherAgent(tracer, meter, logger)
+agent = WeatherAgent(meter, logger)
 
 # Create inner FastAPI app
 inner_app = FastAPI(title="Weather Agent API", version="1.0.0")
@@ -75,7 +77,7 @@ async def health():
 @inner_app.post("/invoke", response_model=InvokeResponse)
 async def invoke(request: InvokeRequest):
     conversation_id = request.conversation_id or f"conv_{uuid.uuid4().hex[:12]}"
-    
+
     fault_config = None
     if request.fault:
         fault_config = FaultConfig(
@@ -84,22 +86,25 @@ async def invoke(request: InvokeRequest):
             probability=request.fault.probability,
             tool=request.fault.tool
         )
-    
+
     # Promote gen_ai attributes to the root HTTP span so the UI can read them
+    enrich(
+        model=agent.model,
+        provider=SYSTEMS.get(agent.model, "openai"),
+        input_messages=[{"role": "user", "parts": [{"type": "text", "content": request.message}]}],
+    )
     root_span = trace_api.get_current_span()
-    root_span.set_attribute("gen_ai.system", agent.model and SYSTEMS.get(agent.model, "openai") or "openai")
     root_span.set_attribute("gen_ai.agent.name", agent.agent_name)
-    root_span.set_attribute("gen_ai.request.model", agent.model)
     root_span.set_attribute("gen_ai.operation.name", "invoke_agent")
-    root_span.set_attribute("gen_ai.input.messages", json.dumps(
-        [{"role": "user", "parts": [{"type": "text", "content": request.message}]}]
-    ))
-    
+
     try:
         response = agent.invoke(request.message, conversation_id, fault_config)
-        root_span.set_attribute("gen_ai.output.messages", json.dumps(
-            [{"role": "assistant", "parts": [{"type": "text", "content": response}]}]
-        ))
+        # Set output on the parent HTTP request span. agent.invoke() runs inside
+        # its own observe() block, so by the time we return here the current
+        # span is the HTTP request span — enrich() intentionally targets it.
+        enrich(
+            output_messages=[{"role": "assistant", "parts": [{"type": "text", "content": response}]}],
+        )
         return InvokeResponse(response=response, conversation_id=conversation_id)
     except AgentError as e:
         return JSONResponse(
@@ -110,7 +115,7 @@ async def invoke(request: InvokeRequest):
         raise HTTPException(status_code=500, detail=f"Agent invocation failed: {str(e)}")
 
 
-# Wrap with ASGI middleware for trace context propagation
+# Wrap with OpenTelemetry middleware for trace context propagation
 app = OpenTelemetryMiddleware(inner_app)
 
 


### PR DESCRIPTION
## Summary
- Replace manual OTel `TracerProvider`/exporter setup with the SDK's `register()` (one-line tracing config)
- Replace `tracer.start_as_current_span()` + manual `span.set_attribute()` calls with `observe()` + `enrich()`
- Net reduction of ~112 lines across orchestrator, events-agent, and weather-agent
- All existing functionality preserved: fault injection, ASGI middleware, MCP integration, metrics, logging

## Changes
| File | What changed |
|---|---|
| `orchestrator/main.py` | `setup_telemetry()` → `register()`, manual spans → `observe()` + `enrich()` |
| `events-agent/main.py` | Same pattern, MCP tool call spans use `observe()` with manual MCP attributes |
| `weather-agent/main.py` | `setup_telemetry()` split: `register()` for tracing + manual metrics/logs setup |
| `weather-agent/server.py` | Manual `span.set_attribute()` → `enrich()` |
| `*/Dockerfile` | Replace `opentelemetry-api` + `opentelemetry-sdk` with `opensearch-genai-observability-sdk-py>=0.2.7` |
| `weather-agent/pyproject.toml` | Same dependency change |

## Before (manual OTel)
```python
def setup_telemetry(service_name, otlp_endpoint):
    resource = Resource.create({"service.name": service_name, ...})
    tracer_provider = TracerProvider(resource=resource)
    tracer_provider.add_span_processor(
        BatchSpanProcessor(OTLPSpanExporter(endpoint=otlp_endpoint, insecure=True))
    )
    trace.set_tracer_provider(tracer_provider)
    return trace.get_tracer(service_name)

# ... later in handler:
with tracer.start_as_current_span("chat", kind=SpanKind.INTERNAL) as chat_span:
    chat_span.set_attribute("gen_ai.operation.name", "chat")
    chat_span.set_attribute("gen_ai.system", SYSTEMS[model])
    chat_span.set_attribute("gen_ai.request.model", model)
    chat_span.set_attribute("gen_ai.usage.input_tokens", input_tokens)
    chat_span.set_attribute("gen_ai.usage.output_tokens", output_tokens)
    chat_span.set_attribute("gen_ai.response.finish_reasons", ["tool_calls"])
```

## After (SDK)
```python
register(endpoint="grpc://localhost:4317", service_name="travel-planner", service_version="1.0.0")

# ... later in handler:
with observe("planning", op=Op.CHAT):
    enrich(model=model, provider=provider,
           input_tokens=input_tokens, output_tokens=output_tokens,
           finish_reason="tool_calls")
```

## Dependencies
Requires [`opensearch-genai-observability-sdk-py >= 0.2.7`](https://pypi.org/project/opensearch-genai-observability-sdk-py/0.2.7/) (released).

## Test plan
- [x] Verify Docker builds succeed with SDK dependency
- [x] Run multi-agent-planner with `docker compose up` and verify traces appear in OpenSearch
- [x] Compare trace attributes between SDK and manual versions are equivalent
- [x] Verify fault injection still works as expected