### PR TITLE
fix: de-dot gRPC message.* spanevent attrs to prevent GenAI event mapping conflict

### DIFF
--- a/docker-compose/otel-collector/config.yaml
+++ b/docker-compose/otel-collector/config.yaml
@@ -62,6 +62,19 @@ processors:
           - delete_key(attributes, "app.ads.contextKeys")
           - set(attributes["rpc_system"], attributes["rpc.system"]) where attributes["rpc.system"] != nil
           - delete_key(attributes, "rpc.system")
+      - context: spanevent
+        statements:
+          # De-dot gRPC message.* event attributes to prevent mapping conflict with
+          # GenAI event attributes where "message" is a plain string value.
+          # Without this, flagd's message.type/message.id/message.uncompressed_size
+          # create an object mapping for events.attributes.message, which conflicts
+          # with GenAI spans that use events.attributes.message as a string.
+          - set(attributes["message_type"], attributes["message.type"]) where attributes["message.type"] != nil
+          - delete_key(attributes, "message.type")
+          - set(attributes["message_id"], attributes["message.id"]) where attributes["message.id"] != nil
+          - delete_key(attributes, "message.id")
+          - set(attributes["message_uncompressed_size"], attributes["message.uncompressed_size"]) where attributes["message.uncompressed_size"] != nil
+          - delete_key(attributes, "message.uncompressed_size")
     log_statements:
       - context: log
         statements:

--- a/examples/strands/code-assistant/main.py
+++ b/examples/strands/code-assistant/main.py
@@ -33,6 +33,12 @@ from utils.prompts import CODE_ASSISTANT_PROMPT
 # This provides better visibility into tool calls during development
 os.environ["STRANDS_TOOL_CONSOLE_MODE"] = "enabled"
 
+# Opt-in to latest GenAI semantic conventions (v1.37+) for richer trace data:
+# - gen_ai.input.messages / gen_ai.output.messages on events (structured I/O)
+# - gen_ai.provider.name instead of gen_ai.system
+# Also include tool definitions in traces for eval-ready spans.
+os.environ["OTEL_SEMCONV_STABILITY_OPT_IN"] = "gen_ai_latest_experimental,gen_ai_tool_definitions"
+
 # ============================================================================
 # OPENTELEMETRY SETUP - OTLP EXPORTER CONFIGURATION
 # ============================================================================


### PR DESCRIPTION
## Problem

When GenAI semantic convention events (`gen_ai.user.message`, `gen_ai.assistant.message`, etc.) are indexed alongside gRPC span events, OpenSearch hits a mapping conflict. gRPC events have `message.type` (object with nested fields) while GenAI events use flat string attributes — the index can't hold both shapes under the same field name.

## Fix

Add spanevent transform rules in the OTel Collector config to rename the gRPC message attributes:
- `message.type` → `message_type`
- `message.id` → `message_id`
- `message.uncompressed_size` → `message_uncompressed_size`

Also enables `OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental` in the Strands code-assistant example for structured `gen_ai.input.messages` and `gen_ai.output.messages` on trace events.

## Files
- `docker-compose/otel-collector/config.yaml` — spanevent transform rules
- `examples/strands/code-assistant/main.py` — semconv opt-in

## Testing
Verified end-to-end: agent traces with GenAI events index cleanly alongside gRPC spans in OpenSearch.