### PR TITLE
docs: address Agent Health documentation feedback

### DIFF
--- a/docs/starlight-docs/src/content/docs/agent-health/index.md
+++ b/docs/starlight-docs/src/content/docs/agent-health/index.md
@@ -2,6 +2,7 @@
 title: "Agent Health"
 description: "Evaluation and observability framework for AI agents with Golden Path trajectory comparison"
 sidebar:
+  label: "Overview"
   order: 1
 ---
 


### PR DESCRIPTION
## Summary
- Add link to [GitHub repository](https://github.com/opensearch-project/agent-health) in intro text for discoverability
- Move Quick Start section higher on the page (above Architecture/Connectors) so it's immediately visible

Addresses feedback from review on #81.

## Test plan
- [ ] Verify the GitHub repo link renders correctly on https://observability.opensearch.org/docs/agent-health/
- [ ] Confirm Quick Start is visible without scrolling past Architecture/Connectors

Signed-off-by: Megha Goyal <goyamegh@amazon.com>