### PR TITLE
feat: add self-monitoring dashboards for docker-compose (OpenSearch health + pipeline health)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -137,6 +137,34 @@ services:
           memory: ${PROMETHEUS_MEMORY_LIMIT}
     logging: *logging
 
+  # OpenSearch Prometheus Exporter - Exposes OpenSearch metrics for Prometheus scraping
+  opensearch-exporter:
+    image: prometheuscommunity/elasticsearch-exporter:v1.10.0
+    container_name: opensearch-exporter
+    command:
+      - --es.uri=${OPENSEARCH_PROTOCOL}://${OPENSEARCH_HOST}:${OPENSEARCH_PORT}
+      - --es.ssl-skip-verify
+      - --es.all
+      - --es.indices
+      - --es.shards
+    environment:
+      - ES_USERNAME=${OPENSEARCH_USER}
+      - ES_PASSWORD=${OPENSEARCH_PASSWORD}
+    ports:
+      - "9114:9114"
+    networks:
+      - observability-stack-network
+    depends_on:
+      opensearch:
+        condition: service_healthy
+        required: false
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 128M
+    logging: *logging
+
   # OpenSearch Dashboards Initialization - Creates workspace, index patterns, and saved queries
   opensearch-dashboards-init:
     image: python:3.11-alpine
@@ -157,6 +185,8 @@ services:
       - ./docker-compose/opensearch-dashboards/init/init-opensearch-dashboards.py:/init.py
       - ./docker-compose/opensearch-dashboards/saved-queries-traces.yaml:/config/saved-queries-traces.yaml
       - ./docker-compose/opensearch-dashboards/saved-queries-metrics.yaml:/config/saved-queries-metrics.yaml
+      - ./docker-compose/opensearch-dashboards/dashboard-opensearch-health.yaml:/config/dashboard-opensearch-health.yaml
+      - ./docker-compose/opensearch-dashboards/dashboard-pipeline-health.yaml:/config/dashboard-pipeline-health.yaml
       - ./docker-compose/opensearch-dashboards/init/architecture.png:/config/architecture.png
     networks:
       - observability-stack-network

--- a/docker-compose/opensearch-dashboards/dashboard-opensearch-health.yaml
+++ b/docker-compose/opensearch-dashboards/dashboard-opensearch-health.yaml
@@ -1,0 +1,62 @@
+# OpenSearch Cluster Health Dashboard — Cluster, index, JVM, and search metrics
+
+dashboard:
+  id: opensearch-cluster-health-dashboard
+  title: OpenSearch Cluster Health
+  description: Cluster status, index stats, JVM health, and indexing performance
+
+panels:
+  # --- Row 1: Cluster Status ---
+  - id: os-cluster-status
+    title: "Cluster Status (0=green, 1=yellow/red)"
+    query: "elasticsearch_cluster_health_status{color=\"yellow\"} or elasticsearch_cluster_health_status{color=\"red\"}"
+    chartType: line
+
+  - id: os-active-shards
+    title: "Active Shards"
+    query: "elasticsearch_cluster_health_active_shards"
+    chartType: line
+
+  # --- Row 2: Index Stats ---
+  - id: os-unassigned-shards
+    title: "Unassigned Shards"
+    query: "elasticsearch_cluster_health_unassigned_shards"
+    chartType: line
+
+  - id: os-docs-count
+    title: "Total Documents"
+    query: "sum(elasticsearch_indices_docs)"
+    chartType: line
+
+  # --- Row 3: Indexing & Storage ---
+  - id: os-indexing-rate
+    title: "Indexing Rate (docs/sec)"
+    query: "rate(elasticsearch_indices_indexing_index_total[5m])"
+    chartType: line
+
+  - id: os-store-size
+    title: "Store Size (bytes)"
+    query: "sum(elasticsearch_indices_store_size_bytes_total)"
+    chartType: line
+
+  # --- Row 4: JVM Health ---
+  - id: os-jvm-heap-used-pct
+    title: "JVM Heap Used %"
+    query: "100 * elasticsearch_jvm_memory_used_bytes{area=\"heap\"} / elasticsearch_jvm_memory_max_bytes{area=\"heap\"}"
+    chartType: line
+
+  - id: os-jvm-gc-rate
+    title: "JVM GC Collection Rate (sec/sec)"
+    query: "rate(elasticsearch_jvm_gc_collection_seconds_sum[5m])"
+    chartType: line
+
+  # --- Row 5: Search & CPU ---
+  - id: os-search-rate
+    title: "Search Rate (queries/sec)"
+    query: "rate(elasticsearch_indices_search_query_total[5m])"
+    chartType: line
+
+  - id: os-cpu-percent
+    title: "OpenSearch CPU %"
+    query: "elasticsearch_os_cpu_percent"
+    chartType: line

--- a/docker-compose/opensearch-dashboards/dashboard-pipeline-health.yaml
+++ b/docker-compose/opensearch-dashboards/dashboard-pipeline-health.yaml
@@ -1,0 +1,138 @@
+# Observability Pipeline Health Dashboard — OTel Collector and Prometheus self-monitoring
+
+dashboard:
+  id: observability-pipeline-health-dashboard
+  title: Observability Pipeline Health
+  description: OTel Collector throughput, Prometheus ingestion, and pipeline health
+
+panels:
+  # --- Row 1: OTel Collector Throughput ---
+  - id: pipeline-otel-spans-received
+    title: "OTel Spans Received/sec"
+    query: "rate(otelcol_receiver_accepted_spans_total[5m])"
+    chartType: line
+
+  - id: pipeline-otel-spans-exported
+    title: "OTel Spans Exported/sec"
+    query: "rate(otelcol_exporter_sent_spans_total[5m])"
+    chartType: line
+
+  # --- Row 2: OTel Metrics & Failures ---
+  - id: pipeline-otel-metrics-received
+    title: "OTel Metrics Received/sec"
+    query: "rate(otelcol_receiver_accepted_metric_points_total[5m])"
+    chartType: line
+
+  - id: pipeline-otel-spans-dropped
+    title: "OTel Spans Dropped/sec"
+    query: "rate(otelcol_exporter_send_failed_spans_total[5m])"
+    chartType: line
+
+  # --- Row 3: OTel Collector Resources ---
+  - id: pipeline-otel-queue-size
+    title: "OTel Exporter Queue Size"
+    query: "otelcol_exporter_queue_size"
+    chartType: line
+
+  - id: pipeline-otel-collector-memory
+    title: "OTel Collector Memory (bytes)"
+    query: "otelcol_process_memory_rss_bytes"
+    chartType: line
+
+  # --- Row 4: OTel Collector CPU & Uptime ---
+  - id: pipeline-otel-collector-cpu
+    title: "OTel Collector CPU Usage"
+    query: "rate(otelcol_process_cpu_seconds_total[5m])"
+    chartType: line
+
+  - id: pipeline-otel-batch-cardinality
+    title: "OTel Batch Metadata Cardinality"
+    query: "otelcol_processor_batch_metadata_cardinality"
+    chartType: line
+
+  # --- Row 5: Prometheus Health ---
+  - id: pipeline-prometheus-ingestion
+    title: "Prometheus Ingestion Rate (chunks/sec)"
+    query: "rate(prometheus_tsdb_head_chunks_created_total[5m])"
+    chartType: line
+
+  - id: pipeline-prometheus-active-series
+    title: "Prometheus Active Time Series"
+    query: "prometheus_tsdb_head_series"
+    chartType: line
+
+  # --- Row 6: Prometheus Storage ---
+  - id: pipeline-prometheus-wal-size
+    title: "Prometheus WAL Size (bytes)"
+    query: "prometheus_tsdb_wal_storage_size_bytes"
+    chartType: line
+
+  - id: pipeline-prometheus-head-chunks
+    title: "Prometheus Head Chunks Size (bytes)"
+    query: "prometheus_tsdb_head_chunks_storage_size_bytes"
+    chartType: line
+
+  - id: pipeline-prometheus-query-latency
+    title: "Prometheus Query Latency P99 (sec)"
+    query: "histogram_quantile(0.99, rate(prometheus_http_request_duration_seconds_bucket{handler=\"/api/v1/query\"}[5m]))"
+    chartType: line
+
+  # --- Row 7: Data Prepper — Logs Pipeline ---
+  - id: pipeline-dp-logs-processed
+    title: "DP Logs Processed/sec"
+    query: "rate(otel_logs_pipeline_recordsProcessed_total[5m])"
+    chartType: line
+
+  - id: pipeline-dp-logs-latency
+    title: "DP Logs Pipeline Latency (avg sec)"
+    query: "rate(otel_logs_pipeline_opensearch_PipelineLatency_seconds_sum[5m]) / rate(otel_logs_pipeline_opensearch_PipelineLatency_seconds_count[5m])"
+    chartType: line
+
+  # --- Row 8: Data Prepper — Traces Pipeline ---
+  - id: pipeline-dp-traces-processed
+    title: "DP Traces Processed/sec"
+    query: "rate(otel_traces_pipeline_recordsProcessed_total[5m])"
+    chartType: line
+
+  - id: pipeline-dp-traces-latency
+    title: "DP Traces Pipeline Latency (avg sec)"
+    query: "rate(traces_raw_pipeline_opensearch_PipelineLatency_seconds_sum[5m]) / rate(traces_raw_pipeline_opensearch_PipelineLatency_seconds_count[5m])"
+    chartType: line
+
+  # --- Row 9: Data Prepper — Metrics Pipeline ---
+  - id: pipeline-dp-metrics-received
+    title: "DP Metrics Received/sec"
+    query: "rate(otlp_metrics_requestsReceived_total[5m])"
+    chartType: line
+
+  - id: pipeline-dp-otlp-requests
+    title: "DP OTLP Requests Received/sec (all)"
+    query: "rate(otlp_traces_requestsReceived_total[5m]) + rate(otlp_logs_requestsReceived_total[5m]) + rate(otlp_metrics_requestsReceived_total[5m])"
+    chartType: line
+
+  # --- Row 10: Data Prepper — Writes & Errors ---
+  - id: pipeline-dp-logs-docs-written
+    title: "DP Logs Docs Written/sec"
+    query: "rate(otel_logs_pipeline_opensearch_documentsSuccess_total[5m])"
+    chartType: line
+
+  - id: pipeline-dp-traces-docs-written
+    title: "DP Traces Docs Written/sec"
+    query: "rate(traces_raw_pipeline_opensearch_documentsSuccess_total[5m])"
+    chartType: line
+
+  # --- Row 11: Data Prepper — Errors & Buffer ---
+  - id: pipeline-dp-bulk-errors
+    title: "DP Bulk Request Errors"
+    query: "sum(rate(otel_logs_pipeline_opensearch_bulkRequestErrors_total[5m])) + sum(rate(traces_raw_pipeline_opensearch_bulkRequestErrors_total[5m]))"
+    chartType: line
+
+  - id: pipeline-dp-buffer-usage
+    title: "DP Buffer Writes/sec"
+    query: "rate(otel_logs_pipeline_BlockingBuffer_recordsWritten_total[5m]) + rate(otel_traces_pipeline_BlockingBuffer_recordsWritten_total[5m])"
+    chartType: line
+
+  - id: pipeline-dp-buffer-capacity
+    title: "DP Buffer Capacity Used %"
+    query: "otlp_pipeline_BlockingBuffer_capacityUsed + otel_logs_pipeline_BlockingBuffer_capacityUsed + otel_traces_pipeline_BlockingBuffer_capacityUsed"
+    chartType: line

--- a/docker-compose/opensearch-dashboards/init/init-opensearch-dashboards.py
+++ b/docker-compose/opensearch-dashboards/init/init-opensearch-dashboards.py
@@ -950,6 +950,119 @@ def create_chart_visualization(workspace_id, vis_id, title, vis_type, field, ind
         return None
 
 
+def create_promql_dashboard_from_yaml(workspace_id, config_path, prometheus_datasource_title="ObservabilityStack_Prometheus"):
+    """Create a dashboard with PromQL explore panels from a YAML config file"""
+    import json
+
+    try:
+        with open(config_path, "r") as f:
+            config = yaml.safe_load(f)
+    except (FileNotFoundError, yaml.YAMLError) as e:
+        print(f"⚠️  Skipping dashboard from {config_path}: {e}")
+        return None
+
+    dashboard_config = config.get("dashboard", {})
+    panel_defs = config.get("panels", [])
+    dashboard_id = dashboard_config.get("id", "promql-dashboard")
+
+    print(f"📊 Creating {dashboard_config.get('title', 'PromQL Dashboard')} dashboard ({len(panel_defs)} panels)...")
+
+    viz_template = json.dumps({
+        "title": "", "chartType": "line",
+        "params": {
+            "addLegend": True, "addTimeMarker": False, "legendPosition": "bottom",
+            "legendTitle": "", "lineMode": "straight", "lineStyle": "line", "lineWidth": 2,
+            "showFullTimeRange": False, "standardAxes": [],
+            "thresholdOptions": {"baseColor": "#00BD6B", "thresholds": [], "thresholdStyle": "off"},
+            "titleOptions": {"show": False, "titleName": ""},
+            "tooltipOptions": {"mode": "all"}
+        },
+        "axesMapping": {"color": "Series", "x": "Time", "y": "Value"}
+    })
+
+    dataset = {
+        "id": prometheus_datasource_title, "title": prometheus_datasource_title,
+        "type": "PROMETHEUS", "language": "PROMQL", "timeFieldName": "Time",
+        "dataSource": {}, "signalType": "metrics"
+    }
+
+    created_ids = []
+    for panel_def in panel_defs:
+        panel_id = panel_def["id"]
+        search_source = json.dumps({
+            "query": {"query": panel_def["query"], "language": "PROMQL", "dataset": dataset},
+            "filter": [], "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index"
+        })
+        payload = {
+            "attributes": {
+                "title": panel_def["title"], "description": "", "hits": 0,
+                "columns": ["_source"], "sort": [], "version": 1, "type": "metrics",
+                "visualization": viz_template,
+                "uiState": json.dumps({"activeTab": "explore_visualization_tab"}),
+                "kibanaSavedObjectMeta": {"searchSourceJSON": search_source}
+            },
+            "references": [{"name": "kibanaSavedObjectMeta.searchSourceJSON.index", "type": "index-pattern", "id": prometheus_datasource_title}]
+        }
+        if workspace_id and workspace_id != "default":
+            payload["workspaces"] = [workspace_id]
+            url = f"{BASE_URL}/w/{workspace_id}/api/saved_objects/explore/{panel_id}"
+        else:
+            url = f"{BASE_URL}/api/saved_objects/explore/{panel_id}"
+        try:
+            response = requests.post(url, auth=(USERNAME, PASSWORD), headers={"Content-Type": "application/json", "osd-xsrf": "true"}, json=payload, verify=False, timeout=10)
+            if response.status_code == 200:
+                created_ids.append(panel_id)
+                print(f"  ✅ {panel_def['title']}")
+            elif response.status_code == 409:
+                requests.put(url, auth=(USERNAME, PASSWORD), headers={"Content-Type": "application/json", "osd-xsrf": "true"}, json={"attributes": payload["attributes"], "references": payload["references"]}, verify=False, timeout=10)
+                created_ids.append(panel_id)
+                print(f"  🔄 {panel_def['title']} (updated)")
+            else:
+                print(f"  ⚠️  {panel_def['title']}: {response.status_code} {response.text[:100]}")
+        except requests.exceptions.RequestException as e:
+            print(f"  ⚠️  {panel_def['title']}: {e}")
+
+    if not created_ids:
+        print("⚠️  No panels created, skipping dashboard")
+        return None
+
+    panels = []
+    references = []
+    for i, pid in enumerate(created_ids):
+        panels.append({"version": "3.6.0", "panelIndex": pid, "gridData": {"i": pid, "x": (i % 2) * 24, "y": (i // 2) * 15, "w": 24, "h": 15}, "panelRefName": f"panel_{i}"})
+        references.append({"name": f"panel_{i}", "type": "explore", "id": pid})
+
+    dashboard_payload = {
+        "attributes": {
+            "title": dashboard_config.get("title", "PromQL Dashboard"),
+            "description": dashboard_config.get("description", ""),
+            "panelsJSON": json.dumps(panels),
+            "optionsJSON": json.dumps({"useMargins": True, "hidePanelTitles": False}),
+            "timeRestore": False,
+            "kibanaSavedObjectMeta": {"searchSourceJSON": json.dumps({})}
+        },
+        "references": references
+    }
+    if workspace_id and workspace_id != "default":
+        dashboard_payload["workspaces"] = [workspace_id]
+        url = f"{BASE_URL}/w/{workspace_id}/api/saved_objects/dashboard/{dashboard_id}"
+    else:
+        url = f"{BASE_URL}/api/saved_objects/dashboard/{dashboard_id}"
+    try:
+        # Always delete and recreate the dashboard so panel order matches YAML
+        requests.delete(url, auth=(USERNAME, PASSWORD), headers={"osd-xsrf": "true"}, verify=False, timeout=10)
+        response = requests.post(url, auth=(USERNAME, PASSWORD), headers={"Content-Type": "application/json", "osd-xsrf": "true"}, json=dashboard_payload, verify=False, timeout=10)
+        if response.status_code == 200:
+            print(f"✅ Created {dashboard_config['title']} dashboard ({len(created_ids)} panels)")
+            return dashboard_id
+        else:
+            print(f"⚠️  Dashboard creation failed: {response.text[:200]}")
+            return None
+    except requests.exceptions.RequestException as e:
+        print(f"⚠️  Error creating dashboard: {e}")
+        return None
+
+
 def create_overview_dashboard(workspace_id):
     """Create an overview landing dashboard with markdown links to all observability features"""
     import json
@@ -1171,6 +1284,10 @@ def main():
 
     # Create overview landing dashboard (becomes the new default)
     create_overview_dashboard(workspace_id)
+
+    # Create self-monitoring dashboards (PromQL explore panels)
+    create_promql_dashboard_from_yaml(workspace_id, "/config/dashboard-pipeline-health.yaml")
+    create_promql_dashboard_from_yaml(workspace_id, "/config/dashboard-opensearch-health.yaml")
 
     # Create saved queries for common agent observability patterns
     create_default_saved_queries(workspace_id)

--- a/docker-compose/prometheus/prometheus.yml
+++ b/docker-compose/prometheus/prometheus.yml
@@ -64,3 +64,24 @@ scrape_configs:
           component: 'telemetry-ingestion'
     # Scrape more frequently for real-time monitoring
     scrape_interval: 10s
+
+  # Scrape OpenSearch metrics via prometheus-opensearch-exporter
+  # Monitors cluster health, JVM, indexing rate, search latency
+  - job_name: 'opensearch'
+    static_configs:
+      - targets: ['opensearch-exporter:9114']
+        labels:
+          service: 'opensearch'
+          component: 'search-storage'
+    scrape_interval: 30s
+
+  # Scrape Data Prepper metrics
+  # Monitors pipeline throughput, bulk errors, buffer usage
+  - job_name: 'data-prepper'
+    metrics_path: '/metrics/prometheus'
+    static_configs:
+      - targets: ['data-prepper:4900']
+        labels:
+          service: 'data-prepper'
+          component: 'telemetry-processing'
+    scrape_interval: 30s


### PR DESCRIPTION
## Description

Adds "observability of the observability stack" — monitors OpenSearch, OTel Collector, Data Prepper, and Prometheus through the same dashboards pipeline.

### New Components

- **opensearch-exporter** service (`prometheuscommunity/elasticsearch-exporter:v1.10.0`) — exposes OpenSearch metrics for Prometheus scraping
- **Prometheus scrape configs** — new jobs for `opensearch` (via exporter) and `data-prepper` (native `/metrics/prometheus`)
- **OpenSearch Cluster Health dashboard** (10 panels) — cluster status, shards, docs count, indexing rate, store size, JVM heap/GC, search rate, CPU
- **Observability Pipeline Health dashboard** (23 panels):
  - OTel Collector: spans/metrics received & exported, drops, queue size, memory, CPU, batch cardinality
  - Data Prepper by signal type: logs/traces/metrics processed/sec, pipeline latency, OTLP requests, docs written/sec, bulk errors, buffer writes/sec, buffer capacity %
  - Prometheus: ingestion rate, active series, storage size, query latency P99

### Key Fixes
- Dashboard panel ordering is now deterministic (delete-then-create instead of upsert)
- Replaced `EndToEndLatency` metric (always zero) with `PipelineLatency`
- Replaced `bufferUsage` gauge (zero at low throughput) with buffer writes/sec rate
- Fixed `showFullTimeRange` causing missing time axes
- Filtered Prometheus ingestion rate to float type to avoid histogram series error

### Testing
- Validated all PromQL queries against live Prometheus instance
- Verified all 23+10 dashboard panels render with data
- Confirmed idempotent re-runs produce correct panel ordering

### Screen Recording

https://github.com/user-attachments/assets/668c5174-7365-4796-9238-436fd0bda4ed

