### PR TITLE
feat: canary generates traces with varying depths and shapes

### DIFF
--- a/docker-compose.examples.yml
+++ b/docker-compose.examples.yml
@@ -50,9 +50,13 @@ services:
     container_name: canary
     environment:
       - TRAVEL_PLANNER_URL=http://travel-planner:8000
+      - WEATHER_AGENT_URL=http://weather-agent:8000
+      - EVENTS_AGENT_URL=http://events-agent:8002
       - CANARY_INTERVAL=${CANARY_INTERVAL}
     depends_on:
       - example-travel-planner
+      - example-weather-agent
+      - example-events-agent
     networks:
       - observability-stack-network
     restart: unless-stopped

--- a/docker-compose/canary/canary.py
+++ b/docker-compose/canary/canary.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python3
 """
 Canary Service - Periodic Travel Planner Invocation with Fault Injection
+
+Generates traces with varying depths and shapes:
+- "normal": standard orchestrator call (37 spans, 4 services)
+- "shallow": direct sub-agent call bypassing orchestrator (5-8 spans, 1-2 services)
+- "deep": multi-destination comparison via sequential orchestrator calls (70+ spans)
 """
 
 import json
@@ -12,11 +17,13 @@ from datetime import datetime
 
 
 TRAVEL_PLANNER_URL = os.getenv("TRAVEL_PLANNER_URL", "http://travel-planner:8000")
+WEATHER_AGENT_URL = os.getenv("WEATHER_AGENT_URL", "http://weather-agent:8000")
+EVENTS_AGENT_URL = os.getenv("EVENTS_AGENT_URL", "http://events-agent:8002")
 CANARY_INTERVAL = int(os.getenv("CANARY_INTERVAL", "30"))
 
 DESTINATIONS = ["Paris", "Tokyo", "London", "Berlin", "Sydney", "New York", "Mumbai", "Seattle"]
 
-# Fault weights
+# Fault weights (applied to normal traces only)
 DEFAULT_FAULT_WEIGHTS = {
     "none": 0.50,
     "weather_error": 0.10,
@@ -28,7 +35,14 @@ DEFAULT_FAULT_WEIGHTS = {
 }
 FAULT_WEIGHTS = json.loads(os.getenv("FAULT_WEIGHTS", json.dumps(DEFAULT_FAULT_WEIGHTS)))
 
-# Map fault names to config
+# Trace shape weights control the mix of shallow / normal / deep traces
+DEFAULT_TRACE_SHAPE_WEIGHTS = {
+    "normal": 0.60,
+    "shallow": 0.25,
+    "deep": 0.15,
+}
+TRACE_SHAPE_WEIGHTS = json.loads(os.getenv("TRACE_SHAPE_WEIGHTS", json.dumps(DEFAULT_TRACE_SHAPE_WEIGHTS)))
+
 FAULT_CONFIGS = {
     "none": None,
     "weather_error": {"weather": {"type": "tool_error"}},
@@ -40,10 +54,14 @@ FAULT_CONFIGS = {
 }
 
 
+def weighted_choice(weights_dict):
+    keys = list(weights_dict.keys())
+    weights = list(weights_dict.values())
+    return random.choices(keys, weights=weights, k=1)[0]
+
+
 def select_fault():
-    fault_types = list(FAULT_WEIGHTS.keys())
-    weights = list(FAULT_WEIGHTS.values())
-    selected = random.choices(fault_types, weights=weights, k=1)[0]
+    selected = weighted_choice(FAULT_WEIGHTS)
     return selected, FAULT_CONFIGS.get(selected)
 
 
@@ -58,30 +76,60 @@ def check_health():
         return False
 
 
-def invoke_planner(destination: str, fault_name: str, fault_config: dict):
-    try:
-        timestamp = datetime.now().strftime("%H:%M:%S")
+def invoke_normal(destination):
+    """Standard orchestrator call — produces normal-depth traces."""
+    fault_name, fault_config = select_fault()
+    payload = {"destination": destination}
+    if fault_config:
+        payload["fault"] = fault_config
+
+    print(f"  [normal] {destination} (fault: {fault_name})")
+    response = requests.post(f"{TRAVEL_PLANNER_URL}/plan", json=payload, timeout=60)
+    data = response.json()
+
+    if response.status_code == 200:
+        status = "partial" if data.get("partial") else "ok"
+        print(f"           → {status}")
+        return True
+    print(f"           → error: {response.status_code}")
+    return False
+
+
+def invoke_shallow(destination):
+    """Direct sub-agent call — produces shallow traces (no orchestrator)."""
+    agent = random.choice(["weather", "events"])
+
+    if agent == "weather":
+        url = f"{WEATHER_AGENT_URL}/invoke"
+        payload = {"message": f"What is the weather in {destination}?"}
+    else:
+        url = f"{EVENTS_AGENT_URL}/events"
         payload = {"destination": destination}
-        if fault_config:
-            payload["fault"] = fault_config
 
-        print(f"[{timestamp}] {destination} (fault: {fault_name})")
+    print(f"  [shallow] {destination} → {agent}-agent")
+    response = requests.post(url, json=payload, timeout=30)
 
-        response = requests.post(f"{TRAVEL_PLANNER_URL}/plan", json=payload, timeout=60)
-        data = response.json()
+    if response.status_code == 200:
+        print(f"            → ok")
+        return True
+    print(f"            → error: {response.status_code}")
+    return False
 
-        if response.status_code == 200:
-            status = "partial" if data.get("partial") else "ok"
-            events_count = len(data.get("events", []))
-            print(f"         → {status}, {events_count} events")
-            return True
-        else:
-            print(f"         → error: {response.status_code}")
-            return False
 
-    except Exception as e:
-        print(f"         → failed: {e}")
-        return False
+def invoke_deep(destinations):
+    """Sequential multi-destination calls — produces deep traces."""
+    print(f"  [deep] comparing {len(destinations)} destinations: {', '.join(destinations)}")
+    results = 0
+    for dest in destinations:
+        payload = {"destination": dest}
+        try:
+            response = requests.post(f"{TRAVEL_PLANNER_URL}/plan", json=payload, timeout=60)
+            if response.status_code == 200:
+                results += 1
+        except Exception:
+            pass
+    print(f"          → {results}/{len(destinations)} succeeded")
+    return results > 0
 
 
 def main():
@@ -89,6 +137,7 @@ def main():
     print("Canary - Travel Planner with Fault Injection")
     print(f"URL: {TRAVEL_PLANNER_URL}")
     print(f"Interval: {CANARY_INTERVAL}s")
+    print(f"Trace shapes: {json.dumps(TRACE_SHAPE_WEIGHTS)}")
     print("=" * 50)
 
     # Wait for service
@@ -106,14 +155,25 @@ def main():
     while True:
         try:
             count += 1
+            timestamp = datetime.now().strftime("%H:%M:%S")
+            shape = weighted_choice(TRACE_SHAPE_WEIGHTS)
             destination = random.choice(DESTINATIONS)
-            fault_name, fault_config = select_fault()
 
-            if invoke_planner(destination, fault_name, fault_config):
+            print(f"[{timestamp}] invocation #{count}")
+
+            if shape == "shallow":
+                ok = invoke_shallow(destination)
+            elif shape == "deep":
+                dests = random.sample(DESTINATIONS, k=random.randint(2, 4))
+                ok = invoke_deep(dests)
+            else:
+                ok = invoke_normal(destination)
+
+            if ok:
                 success += 1
 
             print(f"         Success: {success}/{count} ({100*success/count:.0f}%)\n")
-            
+
             # Sleep after first invocation (not before) so data appears immediately on startup
             time.sleep(CANARY_INTERVAL)
 


### PR DESCRIPTION
## Description

Closes #110.

The canary currently produces traces with uniform structure — every successful trace has exactly 37 spans across 4 services. Fault injection varies error counts but does not change trace depth or shape.

## Changes

Adds three trace shape modes to the canary:

| Shape | Description | Spans | Services |
|-------|-------------|-------|----------|
| **normal** (60%) | Standard orchestrator call with fault injection | ~37 | 4 |
| **shallow** (25%) | Direct sub-agent call, bypassing orchestrator | 5–8 | 1–2 |
| **deep** (15%) | Multi-destination sequential orchestrator calls | 70+ | 4 |

Configurable via `TRACE_SHAPE_WEIGHTS` env var (same pattern as existing `FAULT_WEIGHTS`).

Also adds `WEATHER_AGENT_URL` and `EVENTS_AGENT_URL` env vars to the canary service in `docker-compose.examples.yml`.

## Testing

Rebuilt and ran canary against local stack. Verified all three shapes produce successful invocations:
```
[05:57:15] invocation #1
  [shallow] Seattle → events-agent
            → ok
[05:59:16] invocation #2
  [normal] Sydney (fault: events_error)
           → partial
[06:01:18] invocation #3
  [deep] comparing 3 destinations: New York, Berlin, Sydney
          → 3/3 succeeded
```