### PR TITLE
Agent health docs updates and demo video

### DIFF
--- a/docs/starlight-docs/src/content/docs/agent-health/evaluations/experiments.md
+++ b/docs/starlight-docs/src/content/docs/agent-health/evaluations/experiments.md
@@ -54,7 +54,7 @@ Create experiments with multiple runs using different agents or models. The UI p
 
 ## Generating reports
 
-Generate downloadable reports from experiment results:
+Generate downloadable reports from experiment results for sharing or tracking progress over time.
 
 ```bash
 # HTML report (default)
@@ -67,4 +67,6 @@ npx @opensearch-project/agent-health report -b "My Benchmark" -f pdf -o report.p
 npx @opensearch-project/agent-health report -b "My Benchmark" -f json --stdout
 ```
 
-Reports include judge reasoning, accuracy scores, and improvement suggestions for each test case.
+Reports include a summary of each run (agent, model, pass rate, average accuracy), a per-test-case comparison table across runs, the judge's reasoning and improvement suggestions for each evaluation, and full trajectory steps showing what the agent did.
+
+Use `--runs` to include specific runs, or omit it to include all runs in the experiment.

--- a/docs/starlight-docs/src/content/docs/agent-health/getting-started.md
+++ b/docs/starlight-docs/src/content/docs/agent-health/getting-started.md
@@ -76,10 +76,11 @@ Sample data IDs start with `demo-` prefix and are read-only.
 
 ![Agent Health Dashboard](/docs/images/agent-health/dashboard.png)
 
-The main dashboard displays:
-- Active experiments and their status
-- Recent evaluation runs
-- Quick statistics on pass/fail rates
+Agent Health opens to the Leaderboard Overview — an at-a-glance view of agent performance across all experiments, pre-loaded with sample data.
+
+The top section shows a performance trend chart tracking metrics over time. Use the dropdowns to switch between pass rate, cost, tokens, or latency, and adjust the time range (7 days, 30 days, or all time).
+
+The bottom section is a sortable metrics table showing every experiment × agent combination with columns for run count, pass rate, latency, and cost. Click any column header to sort. Click an experiment or agent name to filter the trend chart to just that selection — active filters appear which can be cleared as required. Each row links to the experiment’s detailed runs view.
 
 ## Run your first evaluation
 

--- a/docs/starlight-docs/src/content/docs/agent-health/getting-started.md
+++ b/docs/starlight-docs/src/content/docs/agent-health/getting-started.md
@@ -80,7 +80,7 @@ Agent Health opens to the Leaderboard Overview — an at-a-glance view of agent 
 
 The top section shows a performance trend chart tracking metrics over time. Use the dropdowns to switch between pass rate, cost, tokens, or latency, and adjust the time range (7 days, 30 days, or all time).
 
-The bottom section is a sortable metrics table showing every experiment × agent combination with columns for run count, pass rate, latency, and cost. Click any column header to sort. Click an experiment or agent name to filter the trend chart to just that selection — active filters appear which can be cleared as required. Each row links to the experiment’s detailed runs view.
+The bottom section is a sortable metrics table showing every experiment and agent combination with columns for run count, pass rate, latency, and cost. Click any column header to sort. Click an experiment or agent name to filter the trend chart to just that selection — active filters appear which can be cleared as required. Each row links to the experiment’s detailed runs view.
 
 ## Run your first evaluation
 

--- a/docs/starlight-docs/src/content/docs/agent-health/index.md
+++ b/docs/starlight-docs/src/content/docs/agent-health/index.md
@@ -36,6 +36,12 @@ Opens http://localhost:4001 with pre-loaded sample data for exploration.
 
 Agent Health uses a client-server architecture where all clients (UI, CLI) access storage through a unified HTTP API. The server handles agent communication via pluggable connectors and proxies LLM judge calls to AWS Bedrock.
 
+## Agent Health and the Observability Stack
+
+Agent Health is a UI and CLI-based evaluation tool for scoring agent quality through LLM judge comparison, running experiments, and generating reports. By default it stores test cases, experiments, runs, and evaluation results as local files.
+
+When pointed at an OpenSearch cluster, including the one running in the [Observability Stack](/docs/get-started/overview/), Agent Health stores test cases, experiments, runs, and evaluation results in OpenSearch indices instead of local files. If the same cluster is receiving OpenTelemetry traces through the stack pipeline, Agent Health can also read those traces and display them alongside evaluation results, connecting what the agent did with how well it performed.
+
 ## Supported connectors
 
 | Connector | Protocol | Description |

--- a/docs/starlight-docs/src/content/docs/agent-health/index.md
+++ b/docs/starlight-docs/src/content/docs/agent-health/index.md
@@ -16,6 +16,10 @@ npx @opensearch-project/agent-health@latest
 
 Opens http://localhost:4001 with pre-loaded sample data for exploration.
 
+## See it in action
+
+<video src="https://github.com/opensearch-project/observability-stack/releases/download/v3.6.0-alpha.1/agent-health-demo.mp4" controls></video>
+
 ## Who uses Agent Health
 
 - **AI teams** building autonomous agents (RCA, customer support, data analysis)


### PR DESCRIPTION
## Summary

Updates Agent Health documentation with improved content for the dashboard overview, experiment reports, and adds context on how Agent Health integrates with the Observability Stack.

## Changes

- **agent-health/index.md**: Added new "Agent Health and the Observability Stack" section explaining how Agent Health connects to OpenSearch for storage and trace visualization
- **agent-health/getting-started.md**: Replaced generic dashboard bullet points with a detailed description of the Leaderboard Overview, including the performance trend chart and sortable metrics table
- **agent-health/evaluations/experiments.md**: Expanded the "Generating reports" section with details on report contents (run summaries, per-test-case comparison, judge reasoning, trajectory steps) and the `--runs` flag
- Demo video as See it in action section

## Test plan

- [ ] Build the docs site and verify no broken links: `cd docs/starlight-docs && npm install && npm run build`
 
- [ ] Verify in preview