### PR TITLE
Switch to prod docker images for OpenSearch, Dashboards, and Data Prepper

### DIFF
--- a/.env
+++ b/.env
@@ -10,8 +10,7 @@ INCLUDE_COMPOSE_EXAMPLES=docker-compose.examples.yml
 INCLUDE_COMPOSE_LOCAL_OPENSEARCH=docker-compose.local-opensearch.yml
 INCLUDE_COMPOSE_LOCAL_OPENSEARCH_DASHBOARDS=docker-compose.local-opensearch-dashboards.yml
 
-# OPENSEARCH_DOCKER_REPO=opensearchproject
-OPENSEARCH_DOCKER_REPO=opensearchstaging
+OPENSEARCH_DOCKER_REPO=opensearchproject
 
 
 # OpenSearch Configuration
@@ -39,6 +38,7 @@ OTEL_COLLECTOR_METRICS_PORT=8888
 # Data Prepper Configuration
 DATA_PREPPER_VERSION=2.15.0-SNAPSHOT-rc2
 DATA_PREPPER_DOCKER_REPO=sgguruda62324
+DATA_PREPPER_IMAGE=opensearch-data-prepper
 DATA_PREPPER_OTLP_PORT=21890
 DATA_PREPPER_HTTP_PORT=21892
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,7 @@ services:
 
   # Data Prepper - Transforms and enriches logs/traces before OpenSearch ingestion
   data-prepper:
-    image: ${DATA_PREPPER_DOCKER_REPO}/opensearch-data-prepper:${DATA_PREPPER_VERSION}
+    image: ${DATA_PREPPER_DOCKER_REPO}/${DATA_PREPPER_IMAGE}:${DATA_PREPPER_VERSION}
     container_name: data-prepper
     pull_policy: always
     platform: linux/amd64


### PR DESCRIPTION
## Summary

Switch OpenSearch and Dashboards docker images from staging repo to official `opensearchproject` Docker Hub repo.

### Changes

| Component | Before | After |
|-----------|--------|-------|
| OpenSearch | `opensearchstaging/opensearch:3.6.0` | `opensearchproject/opensearch:3.6.0` |
| Dashboards | `opensearchstaging/opensearch-dashboards:3.6.0` | `opensearchproject/opensearch-dashboards:3.6.0` |
| Data Prepper | `sgguruda62324/opensearch-data-prepper:2.15.0-SNAPSHOT-rc2` | _(no change — will be covered in a follow-up PR)_ |

Also extracts `DATA_PREPPER_IMAGE` env var in `docker-compose.yml` to make the future Data Prepper image swap a two-line `.env` change.

### Why

- Staging images (`opensearchstaging`) are not intended for public use and are missing plugins (notably ISM)
- Prod images include the full plugin set, enabling ISM for index lifecycle management

### Testing

- All services start and run healthy
- OpenSearch 3.6.0 responding with full plugin set including `opensearch-index-management` (ISM)
- Dashboards and Prometheus healthy