### PR TITLE
chore: add @joshuali925 as maintainer and code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default owners for all files
-*       @kylehounslow @goyamegh @vamsimanohar @anirudha @ps48
+*       @kylehounslow @goyamegh @vamsimanohar @anirudha @ps48 @joshuali925

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -11,3 +11,4 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Vamsi Manohar | [vamsimanohar](https://github.com/vamsimanohar) | Amazon |
 | Anirudha (Ani) Jadhav | [anirudha](https://github.com/anirudha) | Amazon |
 | Shenoy Pratik Gurudatt | [ps48](https://github.com/ps48) | Amazon |
+| Joshua Li | [joshuali925](https://github.com/joshuali925) | Amazon |


### PR DESCRIPTION
### Description
Add @joshuali925 as maintainer and code owner for the observability-stack repository.

  Contributions to observability-stack:

  - fix(docs): resolve npm audit vulnerabilities (#177) (https://github.com/opensearch-project/observability-stack/commit/abc5487)
  - docs: use npx for cli instructions (#184) (https://github.com/opensearch-project/observability-stack/commit/7d355f4)
  - rename release CI to release-drafter (#182) (https://github.com/opensearch-project/observability-stack/commit/067610c)
  - bump cli to v0.1.1 (#176) (https://github.com/opensearch-project/observability-stack/commit/12f69bc)
  - feat(cli): add release drafter for 0.1.0 (#173) (https://github.com/opensearch-project/observability-stack/commit/d46639c)
  - feat(cli): increase fish pipe length and add demo video (#170) (https://github.com/opensearch-project/observability-stack/commit/75af4dd)
  - update CLI get started command to use one line script (#162) (https://github.com/opensearch-project/observability-stack/commit/f801b8a)
  - feat(cli): use domain and pipeline status text for animation (#157) (https://github.com/opensearch-project/observability-stack/commit/bbb986a)
  - feat(cli): improve ASCII animations (#155) (https://github.com/opensearch-project/observability-stack/commit/2398f80)
  - [[cli] Fix bugs and improve UI (#154)](https://github.com/opensearch-project/observability-stack/commit/3c25e5a
   (https://github.com/opensearch-project/observability-stack/commit/3c25e5a))