### PR TITLE
Add ISM retention policies for automatic index cleanup

### DIFF
--- a/.env
+++ b/.env
@@ -42,6 +42,11 @@ DATA_PREPPER_IMAGE=opensearch-data-prepper
 DATA_PREPPER_OTLP_PORT=21890
 DATA_PREPPER_HTTP_PORT=21892
 
+# Index Retention Configuration
+# Number of days to retain trace, log, and service-map indices before deletion.
+# Set to 0 to disable automatic deletion (rollover-only, no cleanup).
+ISM_RETENTION_DAYS=7
+
 # Prometheus Configuration
 PROMETHEUS_VERSION=v3.8.1
 PROMETHEUS_HOST=prometheus

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -704,13 +704,13 @@ docker-compose restart <service-name>
 
 ### Modifying Data Retention
 
-**OpenSearch**: Update ISM policy in `opensearch/` configuration
-**Prometheus**: Update `prometheus.yml`:
-```yaml
-global:
-  storage:
-    tsdb:
-      retention.time: 30d
+**OpenSearch**: Set `ISM_RETENTION_DAYS` in `.env` (default: 7 days). The init script configures ISM policies with rollover + delete. Set to `0` to disable automatic deletion.
+```env
+ISM_RETENTION_DAYS=7
+```
+**Prometheus**: Set `PROMETHEUS_RETENTION` in `.env`:
+```env
+PROMETHEUS_RETENTION=15d
 ```
 
 ### Adding Configuration Comments
@@ -948,12 +948,12 @@ Data Prepper uses a template (`pipelines.template.yaml`) with placeholders proce
 
 ### Index Management
 
-OpenSearch now uses built-in index types managed by Data Prepper:
-- **Logs**: `log-analytics-plain` index type
-- **Traces**: `trace-analytics-plain-raw` index type
-- **Service Maps**: `trace-analytics-service-map` index type
+OpenSearch uses ISM (Index State Management) policies for index lifecycle, configured automatically by the init script:
+- **Traces**: `otel-v1-apm-span-*` — rollover at 50GB/24h, delete after `ISM_RETENTION_DAYS`
+- **Logs**: `logs-otel-v1-*` — rollover at 50GB/24h, delete after `ISM_RETENTION_DAYS`
+- **Service Maps**: `otel-v2-apm-service-map-*` — rollover at 10GB/24h, delete after `ISM_RETENTION_DAYS`
 
-Do not create custom index patterns or ISM policies unless specifically required.
+Data Prepper creates rollover-only policies on startup. The init script overrides them to add a delete state. Data Prepper uses PUT-if-absent semantics and will not overwrite existing policies on restart.
 
 ### Health Checks
 

--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ finch stats --no-stream
 - **Backup and Recovery**: Implement automated backup procedures and test recovery
 - **Monitoring**: Set up monitoring and alerting for the observability stack itself
 - **Resource Limits**: Configure appropriate CPU, memory, and disk quotas
-- **Data Lifecycle**: Implement production-appropriate retention and archival policies
+- **Data Lifecycle**: Default retention is 7 days (`ISM_RETENTION_DAYS` in `.env`). Adjust for production workloads
 
 ### Security Considerations
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -181,6 +181,7 @@ services:
       - OPENSEARCH_DASHBOARDS_PROTOCOL=${OPENSEARCH_DASHBOARDS_PROTOCOL}
       - PROMETHEUS_HOST=${PROMETHEUS_HOST}
       - PROMETHEUS_PORT=${PROMETHEUS_PORT}
+      - ISM_RETENTION_DAYS=${ISM_RETENTION_DAYS:-7}
     volumes:
       - ./docker-compose/opensearch-dashboards/init/init-opensearch-dashboards.py:/init.py
       - ./docker-compose/opensearch-dashboards/saved-queries-traces.yaml:/config/saved-queries-traces.yaml

--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -210,10 +210,14 @@ The docker-compose.yml file mounts these configurations into the containers.
 
 ## Data Retention
 
-- **Logs and Traces**: Managed by OpenSearch index lifecycle policies (default: unlimited in development)
-- **Metrics**: 15 days (configured in Prometheus)
+- **Logs and Traces**: Managed by ISM (Index State Management) policies. Indices roll over every 24 hours (or at 50GB) and are automatically deleted after `ISM_RETENTION_DAYS` (default: 7 days). Configure in `.env`.
+- **Metrics**: 15 days (configured via `PROMETHEUS_RETENTION` in `.env`)
 
-Adjust retention periods by modifying the respective configuration files or OpenSearch index settings.
+To change OpenSearch index retention:
+```env
+# .env — number of days to keep log/trace/service-map indices (0 = never delete)
+ISM_RETENTION_DAYS=7
+```
 
 ## Resource Requirements
 

--- a/docker-compose/opensearch-dashboards/init/init-opensearch-dashboards.py
+++ b/docker-compose/opensearch-dashboards/init/init-opensearch-dashboards.py
@@ -15,6 +15,83 @@ PROMETHEUS_HOST = os.getenv("PROMETHEUS_HOST", "prometheus")
 PROMETHEUS_PORT = os.getenv("PROMETHEUS_PORT", "9090")
 _opensearch_protocol = os.getenv("OPENSEARCH_PROTOCOL", "https")
 OPENSEARCH_ENDPOINT = f"{_opensearch_protocol}://{os.getenv('OPENSEARCH_HOST', 'opensearch')}:{os.getenv('OPENSEARCH_PORT', '9200')}"
+ISM_RETENTION_DAYS = int(os.getenv("ISM_RETENTION_DAYS", "7"))
+
+
+def _ism_policy(policy_id, description, index_patterns, rollover_size, retention_days):
+    """Build an ISM policy with rollover and optional delete."""
+    states = [
+        {
+            "name": "current_write_index",
+            "actions": [{"retry": {"count": 3, "backoff": "exponential", "delay": "1m"},
+                         "rollover": {"min_size": rollover_size, "min_index_age": "24h", "copy_alias": False}}],
+            "transitions": [{"state_name": "delete", "conditions": {"min_index_age": f"{retention_days}d"}}] if retention_days > 0 else [],
+        }
+    ]
+    if retention_days > 0:
+        states.append({"name": "delete", "actions": [{"delete": {}}], "transitions": []})
+    return {
+        "policy": {
+            "policy_id": policy_id,
+            "description": description,
+            "default_state": "current_write_index",
+            "states": states,
+            "ism_template": [{"index_patterns": index_patterns, "priority": 100}],
+        }
+    }
+
+
+def configure_ism_policies():
+    """Create or update ISM policies with retention-based deletion.
+
+    Data Prepper creates rollover-only policies on startup. This function
+    overrides them to add a delete state so old indices are cleaned up
+    automatically. Set ISM_RETENTION_DAYS=0 to keep rollover-only behavior.
+    """
+    if ISM_RETENTION_DAYS == 0:
+        print("⏭️  ISM_RETENTION_DAYS=0, skipping retention policy setup (rollover-only)")
+        return
+
+    print(f"🗂️  Configuring ISM retention policies ({ISM_RETENTION_DAYS}d)...")
+
+    policies = [
+        _ism_policy("raw-span-policy", "Trace span index lifecycle",
+                     ["otel-v1-apm-span-*"], "50gb", ISM_RETENTION_DAYS),
+        _ism_policy("logs-policy", "Log index lifecycle",
+                     ["logs-otel-v1-*"], "50gb", ISM_RETENTION_DAYS),
+        _ism_policy("otel-v2-apm-service-map-policy", "Service map index lifecycle",
+                     ["otel-v2-apm-service-map-*"], "10gb", ISM_RETENTION_DAYS),
+    ]
+
+    for policy_body in policies:
+        pid = policy_body["policy"]["policy_id"]
+        url = f"{OPENSEARCH_ENDPOINT}/_plugins/_ism/policies/{pid}"
+        try:
+            # Get current policy to obtain seq_no/primary_term for update
+            resp = requests.get(url, auth=(USERNAME, PASSWORD), verify=False, timeout=10)
+            if resp.status_code == 200:
+                existing = resp.json()
+                seq_no = existing.get("_seq_no")
+                primary_term = existing.get("_primary_term")
+                resp = requests.put(
+                    f"{url}?if_seq_no={seq_no}&if_primary_term={primary_term}",
+                    auth=(USERNAME, PASSWORD), json=policy_body, verify=False, timeout=10,
+                )
+                if resp.status_code == 200:
+                    print(f"  ✅ Updated {pid}")
+                else:
+                    print(f"  ⚠️  Update {pid}: {resp.status_code} {resp.text[:120]}")
+            elif resp.status_code == 404:
+                resp = requests.put(url, auth=(USERNAME, PASSWORD), json=policy_body,
+                                    verify=False, timeout=10)
+                if resp.status_code in (200, 201):
+                    print(f"  ✅ Created {pid}")
+                else:
+                    print(f"  ⚠️  Create {pid}: {resp.status_code} {resp.text[:120]}")
+            else:
+                print(f"  ⚠️  Get {pid}: {resp.status_code}")
+        except requests.exceptions.RequestException as e:
+            print(f"  ⚠️  Error configuring {pid}: {e}")
 
 def wait_for_dashboards():
     """Wait for OpenSearch Dashboards to be ready"""
@@ -1390,6 +1467,9 @@ def import_ndjson_dashboard(workspace_id, ndjson_path):
 def main():
     """Initialize OpenSearch Dashboards with workspace and datasources"""
     wait_for_dashboards()
+
+    # Configure ISM retention policies (overrides Data Prepper rollover-only defaults)
+    configure_ism_policies()
 
     # Check for existing workspace
     workspace_id = get_existing_workspace()


### PR DESCRIPTION
## Summary

Adds configurable index retention via ISM policies. Data Prepper creates rollover-only policies (no delete state), causing indices to accumulate indefinitely and exhaust disk space.

### How it works

The init script creates/updates ISM policies with a `delete` state that triggers after `ISM_RETENTION_DAYS` (default: 7). This overrides Data Prepper's rollover-only defaults.

**Lifecycle:** `current_write_index` → rollover (50gb or 24h) → delete after 7 days

### Configuration

```env
# .env — set to 0 to disable deletion (rollover-only, matches current behavior)
ISM_RETENTION_DAYS=7
```

### Policies affected

| Policy | Index Pattern | Rollover | Delete After |
|--------|--------------|----------|-------------|
| `raw-span-policy` | `otel-v1-apm-span-*` | 50gb / 24h | 7 days |
| `logs-policy` | `logs-otel-v1-*` | 50gb / 24h | 7 days |
| `otel-v2-apm-service-map-policy` | `otel-v2-apm-service-map-*` | 10gb / 24h | 7 days |

### Files changed

| File | Change |
|------|--------|
| `.env` | Add `ISM_RETENTION_DAYS=7` |
| `docker-compose.yml` | Pass `ISM_RETENTION_DAYS` to init container |
| `init-opensearch-dashboards.py` | Add `configure_ism_policies()` — creates/updates ISM policies with delete state |
| `README.md` | Update Data Lifecycle in production readiness section |
| `docker-compose/README.md` | Rewrite Data Retention section with ISM details |
| `AGENTS.md` | Update Modifying Data Retention and Index Management sections |

---

### Why this is safe — Data Prepper source code evidence

Data Prepper uses **PUT-if-absent** semantics for ISM policies. From [`IsmPolicyManagement.java#checkAndCreatePolicy()`](https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-plugins/opensearch/src/main/java/org/opensearch/dataprepper/plugins/sink/opensearch/index/IsmPolicyManagement.java):

```java
// Data Prepper sends a bare PUT (no if_seq_no/if_primary_term)
Request request = createPolicyRequestFromFile(policyManagementEndpoint, policyJsonString);
try {
    restHighLevelClient.getLowLevelClient().performRequest(request);
} catch (ResponseException e1) {
    if (e1.getMessage().contains("version_conflict_engine_exception")
            || e1.getMessage().contains("resource_already_exists_exception")) {
        // Do nothing - policy already exists in the cluster
    }
}
```

When a policy already exists, DP catches the conflict and **silently skips**. It never updates or overwrites existing policies.

Our init script uses `GET` (to obtain `seq_no`/`primary_term`) → `PUT ?if_seq_no=&if_primary_term=` for safe optimistic-concurrency updates.

Data Prepper's built-in policies are rollover-only with no delete state ([source](https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-plugins/opensearch/src/main/resources/raw-span-policy-with-ism-template.json)). Our policies preserve the same rollover config and add a delete transition.

### Conflict scenario testing

| Scenario | Result | Detail |
|----------|--------|--------|
| Clean start (no policies) | ✅ | Init creates policies with delete state; DP sees they exist, skips |
| DP creates first, then init runs | ✅ | Init updates DP's rollover-only policies to add delete state |
| Init creates first, DP restarts | ✅ | DP gets `version_conflict_engine_exception`, does nothing — our policies survive |
| Both restart simultaneously | ✅ | Init always updates; DP never overwrites — final state always correct |

### End-to-end lifecycle validation

Tested with aggressive settings (`rollover_size=1b`, `rollover_age=1m`, `delete_after=2m`, `ism_job_interval=1`) to observe the full lifecycle in minutes:

```
Test config: rollover_size=1b, rollover_age=1m, delete_after=2m
ISM job_interval=1 minute

=== SURVIVING INDICES (after ~20 min) ===
index                          docs.count store.size
logs-otel-v1-000003                     0       208b
logs-otel-v1-000004                     4     21.5kb
otel-v1-apm-span-000003                 0       208b
otel-v1-apm-span-000004                 0       208b
otel-v2-apm-service-map-000002          0       208b
otel-v2-apm-service-map-000003          0       208b
otel-v2-apm-service-map-000004          0       208b

=== ISM STATE ===
otel-v1-apm-span-000003: Successfully rolled over
otel-v1-apm-span-000004: current write index
logs-otel-v1-000003: Transitioning to delete
logs-otel-v1-000004: current write index
otel-v2-apm-service-map-000002: Transitioning to delete
otel-v2-apm-service-map-000003: Successfully rolled over
otel-v2-apm-service-map-000004: current write index

=== DATA FLOW ===
304 spans sent (OTel Collector → Data Prepper → OpenSearch)
39 log records sent
9100 metric points sent
```

**Observed lifecycle:** `000001` created → rollover to `000002` → `000001` deleted → rollover to `000003` → `000002` deleted → continues...

✅ Rollover triggers correctly (new indices created)
✅ Delete triggers correctly (old indices removed automatically)
✅ Data flow uninterrupted throughout lifecycle
✅ Policies survive Data Prepper restarts
