### PR TITLE
fix: bump requests>=2.33.0 to resolve CVE-2026-25645

### DIFF
--- a/claude-code-observability-plugin/tests/requirements.txt
+++ b/claude-code-observability-plugin/tests/requirements.txt
@@ -1,5 +1,5 @@
 pytest>=7.0
 pyyaml>=6.0
 pydantic>=2.0
-requests>=2.28
+requests>=2.33.0
 hypothesis>=6.0


### PR DESCRIPTION
## Description

Bumps `requests` from `>=2.28` to `>=2.33.0` in `claude-code-observability-plugin/tests/requirements.txt` to resolve [CVE-2026-25645](https://www.mend.io/vulnerability-database/CVE-2026-25645) (CVSS 4.4, Medium).

**Vulnerability:** `requests.utils.extract_zipped_paths()` uses a predictable filename when extracting files from zip archives into the system temp directory. A local attacker with write access to the temp directory could pre-create a malicious file that would be loaded in place of the legitimate one. Fixed in requests v2.33.0.

Resolves #150

> This PR was authored on behalf of @kylehounslow using an AI assistant.