### PR TITLE
fix: exclude & from link generator in UseCases property test

### DIFF
--- a/docs/src/components/UseCases.test.ts
+++ b/docs/src/components/UseCases.test.ts
@@ -104,7 +104,7 @@ describe('UseCases - Property 2: Use case cards contain all required elements', 
           description: fc.string({ minLength: 20, maxLength: 200 })
             .filter(s => s.trim().length >= 20 && !/[<>&"#]/.test(s)),
           link: fc.string({ minLength: 5, maxLength: 50 })
-            .filter(s => (s.startsWith('#') || s.startsWith('http')) && s.trim() === s && !/["']/.test(s)),
+            .filter(s => (s.startsWith('#') || s.startsWith('http')) && s.trim() === s && !/["'&]/.test(s)),
         }),
         (useCase) => {
           // Render use case card
@@ -156,7 +156,7 @@ describe('UseCases - Property 2: Use case cards contain all required elements', 
           description: fc.string({ minLength: 20, maxLength: 200 })
             .filter(s => s.trim().length >= 20 && !/[<>&"#]/.test(s)),
           link: fc.string({ minLength: 5, maxLength: 50 })
-            .filter(s => (s.startsWith('#') || s.startsWith('http')) && s.trim() === s && !/["']/.test(s)),
+            .filter(s => (s.startsWith('#') || s.startsWith('http')) && s.trim() === s && !/["'&]/.test(s)),
         }),
         (useCase) => {
           container.innerHTML = renderUseCaseCard(useCase);
@@ -230,7 +230,7 @@ describe('UseCases - Property 2: Use case cards contain all required elements', 
           description: fc.string({ minLength: 20, maxLength: 200 })
             .filter(s => s.trim().length >= 20 && !/[<>&"#]/.test(s)),
           link: fc.string({ minLength: 5, maxLength: 50 })
-            .filter(s => (s.startsWith('#') || s.startsWith('http')) && s.trim() === s && !/["']/.test(s)),
+            .filter(s => (s.startsWith('#') || s.startsWith('http')) && s.trim() === s && !/["'&]/.test(s)),
         }),
         (useCase) => {
           container.innerHTML = renderUseCaseCard(useCase);
@@ -265,7 +265,7 @@ describe('UseCases - Property 2: Use case cards contain all required elements', 
           description: fc.string({ minLength: 20, maxLength: 200 })
             .filter(s => s.trim().length >= 20 && !/[<>&"#]/.test(s)),
           link: fc.string({ minLength: 5, maxLength: 50 })
-            .filter(s => (s.startsWith('#') || s.startsWith('http')) && s.trim() === s && !/["']/.test(s)),
+            .filter(s => (s.startsWith('#') || s.startsWith('http')) && s.trim() === s && !/["'&]/.test(s)),
         }),
         (useCase) => {
           container.innerHTML = renderUseCaseCard(useCase);
@@ -307,7 +307,7 @@ describe('UseCases - Property 2: Use case cards contain all required elements', 
           description: fc.string({ minLength: 20, maxLength: 200 })
             .filter(s => s.trim().length >= 20 && !/[<>&"#]/.test(s)),
           link: fc.string({ minLength: 5, maxLength: 50 })
-            .filter(s => (s.startsWith('#') || s.startsWith('http')) && s.trim() === s && !/["']/.test(s)),
+            .filter(s => (s.startsWith('#') || s.startsWith('http')) && s.trim() === s && !/["'&]/.test(s)),
         }),
         (useCase) => {
           container.innerHTML = renderUseCaseCard(useCase);
@@ -352,7 +352,7 @@ describe('UseCases - Property 2: Use case cards contain all required elements', 
             description: fc.string({ minLength: 20, maxLength: 200 })
               .filter(s => s.trim().length >= 20 && !/[<>&"#]/.test(s)),
             link: fc.string({ minLength: 5, maxLength: 50 })
-              .filter(s => (s.startsWith('#') || s.startsWith('http')) && s.trim() === s && !/["']/.test(s)),
+              .filter(s => (s.startsWith('#') || s.startsWith('http')) && s.trim() === s && !/["'&]/.test(s)),
           }),
           { minLength: 3, maxLength: 10 }
         ),
@@ -401,7 +401,7 @@ describe('UseCases - Property 2: Use case cards contain all required elements', 
           description: fc.string({ minLength: 20, maxLength: 200 })
             .filter(s => s.trim().length >= 20 && !/[<>&"#]/.test(s)),
           link: fc.string({ minLength: 5, maxLength: 50 })
-            .filter(s => (s.startsWith('#') || s.startsWith('http')) && s.trim() === s && !/["']/.test(s)),
+            .filter(s => (s.startsWith('#') || s.startsWith('http')) && s.trim() === s && !/["'&]/.test(s)),
         }),
         (useCase) => {
           container.innerHTML = renderUseCaseCard(useCase);


### PR DESCRIPTION
## Description

Fixes a flaky property-based test in `docs/src/components/UseCases.test.ts`.

### Root Cause

The `fast-check` link generator could produce strings like `#&#0` which the browser's HTML parser interprets as HTML character references when injected via `innerHTML`. This causes `getAttribute('href')` to return the decoded value (with U+FFFD replacement character) instead of the raw input string, failing the assertion:

```
Expected: "#&#0    #"
Received: "#�    #"
```

The test is non-deterministic — it only fails when `fast-check` happens to generate a link containing `&#` followed by digits.

### Fix

Add `&` to the character exclusion regex in all 7 link generator filters:

```diff
- .filter(s => ... && !/["']/.test(s)),
+ .filter(s => ... && !/["'&]/.test(s)),
```

This is consistent with the `description` generator which already excludes `&` via `/[<>&"#]/.test(s)`.

### Impact

- No change to test coverage — same assertions, same code paths
- No test cases removed — only tightens the random input space
- Fixes the flaky CI failure visible in PR #187 and potentially other PRs

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.*