### PR TITLE
feat: add insecure option for Prometheus remote write

### DIFF
--- a/docker-compose/data-prepper/pipelines.template.yaml
+++ b/docker-compose/data-prepper/pipelines.template.yaml
@@ -110,6 +110,7 @@ service-map-pipeline:
     # Route RED metrics to local Prometheus via remote write
     - prometheus:
         url: "http://PROMETHEUS_HOST:PROMETHEUS_PORT/api/v1/write"
+        insecure: true
         threshold:
           max_events: 500
           flush_interval: 5s


### PR DESCRIPTION
https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sinks/prometheus/#configuration

### Description
_Describe what this change achieves._

Data Prepper Prometheus sink needs `insecure: true` becase url starts with `http`.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
