### PR TITLE
Enable icon side nav v2

### DIFF
--- a/docker-compose/opensearch-dashboards/opensearch_dashboards.template.yml
+++ b/docker-compose/opensearch-dashboards/opensearch_dashboards.template.yml
@@ -84,6 +84,7 @@ data_source.ssl.verificationMode: none
 datasetManagement.enabled: true
 data.savedQueriesNewUI.enabled: true
 opensearchDashboards.branding.useExpandedHeader: false
+opensearchDashboards.enableIconSideNav: true
 
 uiSettings.overrides.home:useNewHomePage: true
 uiSettings.overrides.query:enhancements:enabled: true


### PR DESCRIPTION
## Description
Enable the icon-based side navigation (v2) in OpenSearch Dashboards configuration.

## Type of Change
- [x] Configuration change

## Testing
- [ ] Local docker-compose deployment with updated config
