### PR TITLE
fix(helm): sync chart with Docker Compose (3.7.0, scrape labels, SYNC.md)

### DIFF
--- a/charts/observability-stack/Chart.yaml
+++ b/charts/observability-stack/Chart.yaml
@@ -3,7 +3,7 @@ name: observability-stack
 description: OpenTelemetry-native observability platform for microservices, web apps, and AI agents
 type: application
 version: 0.1.0
-appVersion: "3.6.0"
+appVersion: "3.7.0"
 
 home: https://github.com/opensearch-project/observability-stack
 sources:

--- a/charts/observability-stack/README.md
+++ b/charts/observability-stack/README.md
@@ -271,6 +271,10 @@ For advanced cluster topologies (dedicated cluster manager nodes, coordinating n
 - [Setup multi-node cluster on Kubernetes using Helm](https://opensearch.org/blog/setup-multinode-cluster-kubernetes/) — walkthrough for dedicated cluster manager, data, and coordinating nodes with the official Helm chart
 - [Sizing domains](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/sizing-domains.html) — AWS sizing calculator and methodology (applicable to self-managed clusters)
 
+## Docker Compose Sync
+
+This Helm chart mirrors the Docker Compose configuration for feature parity. See **[SYNC.md](SYNC.md)** for the current sync checkpoint, what stays in sync vs. what is intentionally different, and the full SOP for detecting and fixing drift.
+
 ## Key Values
 
 See `values.yaml` for all options. Notable settings:

--- a/charts/observability-stack/README.md
+++ b/charts/observability-stack/README.md
@@ -112,6 +112,19 @@ The readonly account is recommended as the default for day-to-day monitoring. Sw
 
 The OTel Collector config and Data Prepper pipeline config are rendered as parent-chart templates using `{{ .Release.Name }}`. This means the chart works with any release name — service hostnames are resolved automatically.
 
+## Production TLS
+
+The chart's defaults are tuned for development convenience and use insecure intra-cluster transport for the telemetry pipeline:
+
+- **OTel Collector → Data Prepper** runs over plaintext gRPC (`tls.insecure: true`, `insecure_skip_verify: true`)
+- **Data Prepper → OpenSearch** trusts the cluster's self-signed cert (`insecure: true`)
+- **OpenSearch Dashboards → OpenSearch** uses `verificationMode: none`
+
+For production, you should:
+- Front the cluster with a service mesh (e.g. Istio, Linkerd) for mTLS between pods, **or**
+- Issue a real CA-signed certificate for OpenSearch (cert-manager + a Secret) and flip `tls.insecure` / `insecure_skip_verify` to `false` in `templates/otel-collector-configmap.yaml`, plus the matching settings in the Data Prepper pipeline Secret and Dashboards config
+- Always use the [Gateway API](#exposing-dashboards-gateway-api) section below to terminate TLS for external Dashboards traffic
+
 ## Exposing Dashboards (Gateway API)
 
 The chart includes optional [Gateway API](https://gateway-api.sigs.k8s.io/) resources for exposing OpenSearch Dashboards with TLS. Disabled by default.

--- a/charts/observability-stack/SYNC.md
+++ b/charts/observability-stack/SYNC.md
@@ -54,6 +54,18 @@ git log <SYNC_COMMIT>..HEAD --oneline -- \
   docker-compose/data-prepper/ \
   docker-compose/prometheus/ \
   docker-compose/opensearch-dashboards/
+
+# Discover any NEW services not yet covered by the path list above —
+# every new `docker-compose/<service>/` directory and every new top-level
+# service in any `docker-compose*.yml` should either be reflected in Helm
+# or explicitly listed in "What Is Intentionally Different" below.
+ls docker-compose/ | sort > /tmp/compose-services
+yq -r '.services | keys[]' docker-compose.yml docker-compose.*.yml 2>/dev/null | sort -u > /tmp/compose-svc-keys
+diff /tmp/compose-services <(grep -oE '^[a-z][a-z0-9-]+' charts/observability-stack/templates/*.yaml | sort -u) || true
+
+# When you find a new service, add it to BOTH:
+#   - the "What Stays in Sync" list (above) if it should be deployed in K8s
+#   - the path list in this Step 1 command for future drift checks
 ```
 
 #### Step 2: For each commit, check if the change needs Helm propagation

--- a/charts/observability-stack/SYNC.md
+++ b/charts/observability-stack/SYNC.md
@@ -1,0 +1,136 @@
+# Helm Chart ↔ Docker Compose Sync
+
+This Helm chart mirrors the Docker Compose configuration for feature parity across deployment modes. This file tracks the sync state and provides an SOP for detecting and fixing drift.
+
+## Sync Checkpoint
+
+| Field | Value |
+|-------|-------|
+| **Last synced commit** | `367d855` |
+| **Commit message** | `config(opensearch-dashboards): enable icon side nav v2 (#227)` |
+| **Date** | 2026-05-07 |
+| **Synced by** | @sgguruda |
+
+## What Stays in Sync
+
+These must be updated in the Helm chart whenever they change in Docker Compose:
+
+- **Image versions and repos** — `opensearch`, `opensearch-dashboards`, `data-prepper`, `otel-collector` in `.env` must match `values.yaml`
+- **OTel Collector config** — receivers, processors (especially transform statements), exporters, pipelines, telemetry settings
+- **Data Prepper pipelines** — routing logic, processor names/params, sink config, buffer/worker/delay values
+- **Prometheus** — scrape targets, intervals, labels, OTLP config, command flags
+- **OpenSearch Dashboards** — all feature flags and settings in `opensearch_dashboards.template.yml`
+
+## What Is Intentionally Different (Do NOT Sync)
+
+| Difference | Docker Compose | Helm | Reason |
+|---|---|---|---|
+| Service names | Hardcoded (`data-prepper:21890`) | Templated (`{{ .Release.Name }}-data-prepper:21890`) | Helm supports multiple releases |
+| Credentials | sed template placeholders | Kubernetes Secrets + Helm templates | Different secret injection models |
+| Resource limits | Dev-sized (500M–2G) | Production-sized (2Gi–4Gi) | Different deployment targets |
+| Prometheus cluster label | `observability-stack-dev` | `observability-stack` | Distinguishes environments |
+| Health check extension | Absent | Present (`health_check` on 13133) | K8s liveness probes need it |
+| node-exporter / kube-state-metrics | Absent | Present via kubernetes_sd | K8s-only metrics |
+| Replicas | 1 (single container) | 3 | Production HA |
+| Gateway API / Ingress / RBAC | Absent | Optional templates | K8s-only infrastructure |
+| Data Prepper `peer_forwarder` | Absent | `ssl: false` | K8s multi-pod clustering |
+| Prometheus port in exporter | `prometheus:9090` | `prometheus-server:80` | K8s service routing convention |
+
+## SOP: Detecting and Fixing Drift
+
+### For AI Agents
+
+When asked to check or fix drift between Docker Compose and Helm:
+
+#### Step 1: Identify what changed since last sync
+
+```bash
+# Get commits that touched Docker Compose configs since last sync
+git log <SYNC_COMMIT>..HEAD --oneline -- \
+  .env \
+  docker-compose.yml \
+  docker-compose.*.yml \
+  docker-compose/otel-collector/ \
+  docker-compose/data-prepper/ \
+  docker-compose/prometheus/ \
+  docker-compose/opensearch-dashboards/
+```
+
+#### Step 2: For each commit, check if the change needs Helm propagation
+
+Read the diff for each commit. Ask:
+1. Did an image version or repo change in `.env`? → Update `values.yaml` image tags/repos + `Chart.yaml` appVersion
+2. Did a setting change in `docker-compose/otel-collector/config.yaml`? → Update `templates/otel-collector-configmap.yaml`
+3. Did a pipeline change in `docker-compose/data-prepper/pipelines.template.yaml`? → Update `templates/data-prepper-pipeline-secret.yaml`
+4. Did a Prometheus config change in `docker-compose/prometheus/prometheus.yml`? → Update the `prometheus:` section in `values.yaml`
+5. Did a Dashboards setting change in `docker-compose/opensearch-dashboards/opensearch_dashboards.template.yml`? → Update the `opensearch-dashboards.config` block in `values.yaml`
+6. Did a new service get added to `docker-compose.yml`? → May need a new template in `templates/`
+
+Skip changes to: examples, docs, tests, load-testing, compat, aws, terraform — these don't affect core Helm chart.
+
+#### Step 3: Make the corresponding Helm changes
+
+Map Docker Compose patterns to Helm equivalents:
+
+| Docker Compose | Helm Equivalent |
+|---|---|
+| `.env` variable `FOO_VERSION=x.y.z` | `values.yaml` image tag field |
+| `docker-compose/otel-collector/config.yaml` | `templates/otel-collector-configmap.yaml` (inline config) |
+| `docker-compose/data-prepper/pipelines.template.yaml` | `templates/data-prepper-pipeline-secret.yaml` |
+| `docker-compose/prometheus/prometheus.yml` | `values.yaml` → `prometheus.serverFiles` + `prometheus.extraScrapeConfigs` |
+| `docker-compose/opensearch-dashboards/opensearch_dashboards.template.yml` | `values.yaml` → `opensearch-dashboards.config.opensearch_dashboards.yml` |
+| Docker Compose command flags | `values.yaml` → relevant `extraFlags` or `command` fields |
+| New service in `docker-compose.yml` | New template in `templates/` or new subchart dependency |
+
+When translating configs:
+- Replace hardcoded service names with `{{ .Release.Name }}-<service-name>`
+- Replace credential placeholders with Helm template expressions (`{{ .Values.opensearchUsername | quote }}`)
+- Keep the "intentionally different" items as-is (see table above)
+
+#### Step 4: Validate
+
+```bash
+# YAML syntax check
+python3 -c "import yaml; yaml.safe_load(open('charts/observability-stack/values.yaml'))"
+
+# Helm lint (if helm is available)
+helm lint charts/observability-stack
+
+# Template render check
+helm template obs charts/observability-stack
+```
+
+#### Step 5: Update this file
+
+Update the **Sync Checkpoint** table at the top of this file with:
+- The new commit hash (HEAD of main after the Docker Compose changes)
+- The commit message
+- Today's date
+- Your identifier
+
+#### Step 6: Create PR
+
+Title format: `fix(helm): sync Helm chart with Docker Compose (<short summary>)`
+
+PR body should include:
+- Which Docker Compose commits triggered the sync (with PR numbers)
+- Summary of what changed in the Helm chart
+- Verification steps performed
+
+### Quick Drift Check Commands
+
+```bash
+# Compare image versions
+grep -E 'VERSION|tag:' .env charts/observability-stack/values.yaml
+
+# List Docker Compose changes since last sync
+git log 367d855..HEAD --oneline -- .env docker-compose.yml 'docker-compose.*.yml' 'docker-compose/'
+
+# Diff OTel Collector configs (requires helm + yq)
+diff <(sed '/^#/d' docker-compose/otel-collector/config.yaml) \
+     <(helm template obs charts/observability-stack | yq 'select(.kind=="ConfigMap" and .metadata.name=="otel-collector-config") | .data.relay')
+
+# Diff Dashboards settings (requires yq)
+diff docker-compose/opensearch-dashboards/opensearch_dashboards.template.yml \
+     <(yq '.opensearch-dashboards.config.opensearch_dashboards\.yml' charts/observability-stack/values.yaml)
+```

--- a/charts/observability-stack/templates/otel-collector-configmap.yaml
+++ b/charts/observability-stack/templates/otel-collector-configmap.yaml
@@ -76,6 +76,7 @@ data:
         endpoint: "{{ .Release.Name }}-data-prepper:21890"
         tls:
           insecure: true
+          insecure_skip_verify: true
       otlphttp/prometheus:
         endpoint: "http://{{ .Release.Name }}-prometheus-server:80/api/v1/otlp"
         tls:
@@ -86,6 +87,8 @@ data:
     service:
       extensions: [health_check]
       telemetry:
+        logs:
+          level: info
         metrics:
           readers:
             - pull:

--- a/charts/observability-stack/values.yaml
+++ b/charts/observability-stack/values.yaml
@@ -13,8 +13,8 @@ opensearch:
   singleNode: false
   replicas: 3
   image:
-    repository: "opensearchproject/opensearch"
-    tag: "3.6.0"
+    repository: "opensearchstaging/opensearch"
+    tag: "3.7.0"
   resources:
     requests:
       memory: "4Gi"
@@ -77,8 +77,8 @@ opensearch-dashboards:
   enabled: true
   replicaCount: 3
   image:
-    repository: "opensearchproject/opensearch-dashboards"
-    tag: "3.6.0"
+    repository: "opensearchstaging/opensearch-dashboards"
+    tag: "3.7.0"
   resources:
     requests:
       cpu: "500m"
@@ -114,13 +114,19 @@ opensearch-dashboards:
       opensearch.hosts: ["https://opensearch-cluster-master:9200"]
       opensearch.ssl.verificationMode: none
       opensearch.requestTimeout: 30000
+      opensearch.pingTimeout: 3000
       opensearch.requestHeadersAllowlist: ["authorization", "securitytenant"]
       opensearch_security.multitenancy.enabled: false
+      opensearch_security.multitenancy.tenants.preferred: ["Private", "Global"]
       opensearch_security.readonly_mode.roles: ["kibana_read_only"]
       console.enabled: true
+      vis_type_vega.enableExternalUrls: true
       server.maxPayloadBytes: 1048576
+      server.compression.enabled: true
+      server.cors: true
       savedObjects.maxImportPayloadBytes: 26214400
       csp.strict: false
+      csp.warnLegacyBrowsers: false
       explore.enabled: true
       explore.discoverTraces.enabled: true
       explore.discoverMetrics.enabled: true
@@ -131,6 +137,11 @@ opensearch-dashboards:
       datasetManagement.enabled: true
       data.savedQueriesNewUI.enabled: true
       opensearchDashboards.branding.useExpandedHeader: false
+      opensearchDashboards.enableIconSideNav: true
+      logging:
+        quiet: false
+        verbose: false
+        dest: stdout
       uiSettings.overrides.home:useNewHomePage: true
       uiSettings.overrides.query:enhancements:enabled: true
       uiSettings.overrides.explore:experimental: true
@@ -249,6 +260,8 @@ prometheus:
     extraFlags:
       - "web.enable-remote-write-receiver"
       - "web.enable-otlp-receiver"
+      - "web.enable-lifecycle"
+      - "enable-feature=exemplar-storage"
     global:
       scrape_interval: 60s
       scrape_timeout: 10s
@@ -279,15 +292,24 @@ prometheus:
     - job_name: otel-collector
       static_configs:
         - targets: ['{{ .Release.Name }}-opentelemetry-collector:8888']
+          labels:
+            service: 'otel-collector'
+            component: 'telemetry-ingestion'
       scrape_interval: 10s
     - job_name: opensearch
       static_configs:
         - targets: ['{{ .Release.Name }}-observability-stack-opensearch-exporter:9114']
+          labels:
+            service: 'opensearch'
+            component: 'search-storage'
       scrape_interval: 30s
     - job_name: data-prepper
       metrics_path: '/metrics/prometheus'
       static_configs:
         - targets: ['{{ .Release.Name }}-data-prepper:4900']
+          labels:
+            service: 'data-prepper'
+            component: 'telemetry-processing'
       scrape_interval: 30s
     - job_name: node-exporter
       kubernetes_sd_configs:


### PR DESCRIPTION
### Description

Resolves configuration drift between the Helm chart and Docker Compose deployments up through commit 367d855 (Dashboards icon side nav v2).

  - Bump OpenSearch / Dashboards images to 3.7.0 from the `opensearchstaging` repo (3.7.0 is pre-release and not yet on `opensearchproject`); bump `Chart.yaml` appVersion to 3.7.0
  - Harden OTel Collector: add `insecure_skip_verify: true` on the `otlp/opensearch` exporter and `telemetry.logs.level: info`
  - Add missing OpenSearch Dashboards settings: `opensearch.pingTimeout`, `opensearch_security.multitenancy.tenants.preferred`, `vis_type_vega.enableExternalUrls`, `server.compression.enabled`, `server.cors`, `csp.warnLegacyBrowsers`, `opensearchDashboards.enableIconSideNav`, and the `logging` block
  - Add Prometheus `extraFlags`: `web.enable-lifecycle` and `enable-feature=exemplar-storage`
  - Add `service` / `component` static labels to the otel-collector, opensearch, and data-prepper Prometheus scrape jobs for parity with `docker-compose/prometheus/prometheus.yml`
  - New `charts/observability-stack/SYNC.md` documenting the last-synced Compose commit (`367d855`), what stays in sync vs. what is intentionally different, and a 6-step SOP for AI agents and contributors to detect and fix drift; README points to it

Cortex / Alertmanager / alerting from #226 (`85a64ca`) is intentionally **out of scope** and will be synced in a separate follow-up PR. The SYNC.md checkpoint at `367d855` ensures the drift SOP will surface that work as still pending.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
