### PR TITLE
fix(alerting-init): merge cortex+opensearch alerting init containers

### DIFF
--- a/docker-compose.otel-demo.yml
+++ b/docker-compose.otel-demo.yml
@@ -768,50 +768,40 @@ services:
   # ******************
   # Demo-only Alerting Extensions
   # ******************
-  # Demo-only rule loader. Runs alongside the base cortex-rules-init container
-  # (defined in docker-compose.yml) and loads the `otel_demo` Cortex namespace
-  # only. Named separately rather than overlaying the base service because
-  # Docker Compose >= v2.38 rejects service-name overlays on `include:`-imported
-  # resources. Both containers hit the same idempotent Ruler upsert API.
-  cortex-rules-init-otel-demo:
+  # Demo-only one-shot loader for OTel Demo alerting:
+  #   1. Cortex ruler rules from /rules/otel_demo
+  #   2. OpenSearch alerting monitors for demo traces/logs (checkout, payment, …)
+  # Mirrors the base `alerting-rules-monitors-init` container — both stages run
+  # regardless of each other's outcome and the container exits non-zero on any
+  # failure. Named separately from the base container rather than overlaying it
+  # because Docker Compose >= v2.38 rejects service-name overlays on
+  # `include:`-imported resources. Both containers hit idempotent upsert APIs.
+  otel-demo-alerting-rules-monitors-init:
     image: python:3.11-alpine
-    container_name: cortex-rules-init-otel-demo
-    # `sleep infinity` after success so `docker compose up --wait` is happy.
-    command: sh -c "pip install requests pyyaml && python /init.py && exec sleep infinity"
+    container_name: otel-demo-alerting-rules-monitors-init
+    command:
+      - sh
+      - -c
+      - |
+        pip install requests pyyaml || exit 1
+        fail=0
+        echo "=== Loading Cortex rules (otel_demo) ==="
+        python /init-cortex-rules.py || fail=1
+        echo "=== Creating OpenSearch monitors (otel_demo) ==="
+        python /init-otel-demo-monitors.py || fail=1
+        exit $$fail
     depends_on:
       prometheus:
         condition: service_healthy
-    volumes:
-      - ./docker-compose/cortex/init-cortex-rules.py:/init.py
-      - ./docker-compose/prometheus/rules-otel-demo:/rules/otel_demo:ro
-    <<: *network
-    restart: "no"
-    # Mirror the base cortex-rules-init healthcheck: the script touches
-    # /tmp/rules-loaded on a clean load, and `--wait` blocks on it so callers
-    # that query /api/v1/rules/otel_demo after --wait see the rules already in
-    # Cortex. 40×3s=120s covers pip install + load time.
-    healthcheck:
-      test: ["CMD", "test", "-f", "/tmp/rules-loaded"]
-      interval: 3s
-      timeout: 2s
-      retries: 40
-      start_period: 10s
-    logging: *logging
-
-  # OTel Demo Monitors Init - Creates OpenSearch alerting monitors for demo
-  # traces/logs (checkout, payment, cart, frontend). Idempotent.
-  otel-demo-monitors-init:
-    image: python:3.11-alpine
-    container_name: otel-demo-monitors-init
-    command: sh -c "pip install requests && python /init.py"
-    depends_on:
       opensearch:
         condition: service_healthy
     environment:
       - OPENSEARCH_USER=${OPENSEARCH_USER}
       - OPENSEARCH_PASSWORD=${OPENSEARCH_PASSWORD}
     volumes:
-      - ./docker-compose/opentelemetry-demo/init-otel-demo-monitors.py:/init.py
+      - ./docker-compose/cortex/init-cortex-rules.py:/init-cortex-rules.py
+      - ./docker-compose/prometheus/rules-otel-demo:/rules/otel_demo:ro
+      - ./docker-compose/opentelemetry-demo/init-otel-demo-monitors.py:/init-otel-demo-monitors.py
     <<: *network
     restart: "no"
     logging: *logging

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -202,56 +202,39 @@ services:
       retries: 10
     logging: *logging
 
-  # Cortex Rules Initialization - Loads alerting rules via the Cortex Ruler API.
-  # Scans /rules/<namespace>/*.yml and POSTs each group. Idempotent.
-  # Base stack rules (/rules/stack) are always loaded. The otel-demo overlay
-  # extends this container to also mount /rules/otel_demo.
-  cortex-rules-init:
+  # Alerting Rules + Monitors Init - One-shot loader for stack-wide alerting:
+  #   1. Cortex ruler rules from /rules/stack (Prometheus rule groups)
+  #   2. OpenSearch alerting monitors that watch the stack itself (cluster health, etc)
+  # Both stages are idempotent. The container runs both regardless of each
+  # other's outcome and exits non-zero if either failed, so a partial failure
+  # is visible but doesn't block the working half. The otel-demo overlay
+  # defines a sibling container that loads its own rules/monitors.
+  alerting-rules-monitors-init:
     image: python:3.11-alpine
-    container_name: cortex-rules-init
-    # `sleep infinity` after the script succeeds so `docker compose up --wait`
-    # doesn't trip over a clean exit — `--wait` treats any exited container as
-    # a failure unless a dependent uses `service_completed_successfully`.
-    command: sh -c "pip install requests pyyaml && python /init.py && exec sleep infinity"
+    container_name: alerting-rules-monitors-init
+    command:
+      - sh
+      - -c
+      - |
+        pip install requests pyyaml || exit 1
+        fail=0
+        echo "=== Loading Cortex rules ==="
+        python /init-cortex-rules.py || fail=1
+        echo "=== Creating OpenSearch monitors ==="
+        python /init-stack-monitors.py || fail=1
+        exit $$fail
     depends_on:
       prometheus:
         condition: service_healthy
-    volumes:
-      - ./docker-compose/cortex/init-cortex-rules.py:/init.py
-      - ./docker-compose/prometheus/rules-stack:/rules/stack:ro
-    networks:
-      - observability-stack-network
-    restart: "no"
-    # The init script touches /tmp/rules-loaded after a clean load. Without
-    # this check `--wait` returns the moment pip starts (container "running"),
-    # well before rules are actually in Cortex — so any caller that queries
-    # /api/v1/rules immediately after --wait sees an empty list. 40×3s=120s
-    # covers pip install + load.
-    healthcheck:
-      test: ["CMD", "test", "-f", "/tmp/rules-loaded"]
-      interval: 3s
-      timeout: 2s
-      retries: 40
-      start_period: 10s
-    logging: *logging
-
-  # OpenSearch Stack Monitors Init - Creates alerting monitors that watch the
-  # health of the observability stack itself (cluster health, etc). Idempotent
-  # by monitor name. The init script hardcodes https://opensearch:9200, so it
-  # hard-depends on local OpenSearch — without it there's nothing to target.
-  opensearch-stack-monitors-init:
-    image: python:3.11-alpine
-    container_name: opensearch-stack-monitors-init
-    command: sh -c "pip install requests && python /init.py"
-    depends_on:
       opensearch:
         condition: service_healthy
-        required: true
     environment:
       - OPENSEARCH_USER=${OPENSEARCH_USER}
       - OPENSEARCH_PASSWORD=${OPENSEARCH_PASSWORD}
     volumes:
-      - ./docker-compose/opensearch-dashboards/init/init-stack-monitors.py:/init.py
+      - ./docker-compose/cortex/init-cortex-rules.py:/init-cortex-rules.py
+      - ./docker-compose/prometheus/rules-stack:/rules/stack:ro
+      - ./docker-compose/opensearch-dashboards/init/init-stack-monitors.py:/init-stack-monitors.py
     networks:
       - observability-stack-network
     restart: "no"

--- a/docker-compose/prometheus/rules-stack/stack-alerts.yml
+++ b/docker-compose/prometheus/rules-stack/stack-alerts.yml
@@ -1,5 +1,5 @@
 # Observability Stack health alerting rules
-# Loaded into Cortex's `stack` ruler namespace by cortex-rules-init (base compose).
+# Loaded into Cortex's `stack` ruler namespace by alerting-rules-monitors-init (base compose).
 # These rules run whether or not the otel-demo overlay is enabled.
 #
 # Every rule here targets metrics emitted or scraped by the stack itself

--- a/docs/starlight-docs/src/content/docs/alerting/index.md
+++ b/docs/starlight-docs/src/content/docs/alerting/index.md
@@ -65,7 +65,7 @@ OpenSearch Alerting is one of two alerting surfaces in the stack. The other is a
 
 ### Rule file locations
 
-Cortex rules are shipped as YAML files mounted into the `cortex-rules-init` container on startup. Two namespaces are loaded:
+Cortex rules are shipped as YAML files mounted into the `alerting-rules-monitors-init` container on startup (and `otel-demo-alerting-rules-monitors-init` when the otel-demo overlay is enabled). Two namespaces are loaded:
 
 - **`stack`** — watches the observability stack itself. Loaded always.
   - File: `docker-compose/prometheus/rules-stack/stack-alerts.yml`
@@ -77,7 +77,7 @@ Cortex rules are shipped as YAML files mounted into the `cortex-rules-init` cont
 To add or edit rules, change the YAML file and re-run the loader:
 
 ```bash
-docker compose up -d --force-recreate cortex-rules-init
+docker compose up -d --force-recreate alerting-rules-monitors-init
 ```
 
 The loader upserts via `POST /api/v1/rules/{namespace}`, so re-runs are idempotent and edits take effect immediately. Inspect loaded groups at `http://localhost:9090/api/v1/rules/stack` or `http://localhost:9090/api/v1/rules/otel_demo` (Cortex returns YAML from this Ruler API endpoint).


### PR DESCRIPTION
## Summary

Collapse the four alerting-related init containers into two — one per deployment scope — and clean up the `sleep infinity` workaround on the Cortex inits along the way.

| Before (4 containers) | After (2 containers) |
|---|---|
| `cortex-rules-init` + `opensearch-stack-monitors-init` | **`alerting-rules-monitors-init`** (base) |
| `cortex-rules-init-otel-demo` + `otel-demo-monitors-init` | **`otel-demo-alerting-rules-monitors-init`** (otel-demo overlay) |

Each merged container runs the Cortex rule loader **and** the OpenSearch monitor creator in sequence. Both stages run regardless of each other's outcome (idempotent reruns are safe), and the container exits non-zero if either stage failed — partial failures stay visible without blocking the working half.

## Why

Reviewer feedback on the prior revision flagged that having four separate alerting init containers was more sprawl than the work warranted. They split cleanly along scope (base vs otel-demo) and signal type (Cortex vs OpenSearch), but the underlying scripts are short-lived and tightly related, so collapsing them per-scope cuts container count without losing isolation between base and demo flows. Existing scripts are reused as-is — only the compose wrapper changed.

This revision also drops the `exec sleep infinity` + `/tmp/rules-loaded` healthcheck workaround that was on the cortex init containers. A clean exit 0 with `restart: "no"` is already treated as success by `docker compose up --wait` in the pinned version (and was already the pattern used by the opensearch inits). The merged containers only exit after both scripts return, so `--wait` correctly blocks until rules+monitors are actually loaded — removing the ~30 s rules-not-yet-visible window flagged in PR-226 testing.

## Behavior

- `depends_on`: both `prometheus: service_healthy` AND `opensearch: service_healthy` (each merged container needs both).
- Failure semantics: if `pip install` fails, container exits 1 immediately. Otherwise both Python scripts always run; container exit code is 0 iff both succeeded.
- Idempotency: Cortex rule upserts (`POST /api/v1/rules/{namespace}` returns 202 on create or replace) and OpenSearch monitor creates (skip-if-name-exists) are both safe to re-run.

## Test plan

Validated locally with full teardown (`docker compose down -v --remove-orphans`) between rounds.

### Round 1 — base only (otel-demo OFF)

- [x] `docker compose up -d --wait --wait-timeout 360` returns exit 0 (23 s)
- [x] `alerting-rules-monitors-init` shows `Exited (0)`
- [x] `otel-demo-alerting-rules-monitors-init` does not exist (overlay disabled)
- [x] `GET /api/v1/rules` → `stack` namespace only (1 group, 4 rules)
- [x] OpenSearch monitors total = 1 ("Observability Stack - Cluster Health Red")

### Round 2 — with otel-demo overlay

- [x] `INCLUDE_COMPOSE_OTEL_DEMO=docker-compose.otel-demo.yml docker compose up -d --wait` returns exit 0 (29 s)
- [x] Both `alerting-rules-monitors-init` and `otel-demo-alerting-rules-monitors-init` show `Exited (0)`
- [x] `GET /api/v1/rules` → `stack` (1 group) + `otel_demo` (3 groups, 9 rules)
- [x] OpenSearch monitors total = 6 (1 stack health + 5 demo: Checkout, Payment, Frontend logs, Slow Frontend, Cart)

## Files touched

- `docker-compose.yml` — merged base init container
- `docker-compose.otel-demo.yml` — merged otel-demo init container
- `docker-compose/prometheus/rules-stack/stack-alerts.yml` — doc comment now references new container name
- `docs/starlight-docs/src/content/docs/alerting/index.md` — container name in user-facing rules-loader instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)