### PR TITLE
fix(test): stop flaky empty-alt failure in Performance property test

### DIFF
--- a/docs/src/components/Performance.test.ts
+++ b/docs/src/components/Performance.test.ts
@@ -233,7 +233,7 @@ describe('Performance - Property 6: Below-fold images are lazy-loaded', () => {
               src: fc.string({ minLength: 5, maxLength: 100 })
                 .map(s => `/images/${s.replace(/[^a-z0-9.-]/gi, '_')}.jpg`),
               alt: fc.string({ minLength: 3, maxLength: 100 })
-                .map(s => s.replace(/[<>"'&]/g, '')),
+                .map(s => s.replace(/[<>"'&]/g, '') || 'image description'),
               isBelowFold: fc.boolean(),
               width: fc.integer({ min: 100, max: 1200 }),
               height: fc.integer({ min: 100, max: 800 })


### PR DESCRIPTION
## Summary

- The `Performance` test "should ensure images have proper attributes for performance" generates `alt` strings via fast-check, then strips `[<>"'&]`. When the generated value contains only those characters, the result is empty and `expect(alt).toBeTruthy()` fails.
- Other tests in the same file already apply a `|| 'image description'` fallback for the same reason; this one was missing it.
- Observed flake on CI for unrelated PRs (e.g. #221) — failed seed `1684160625`.

## Test plan

- [x] `npx vitest --run src/components/Performance.test.ts` (5/5 pass locally, including the previously-failing case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)