### PR TITLE
fix(data-prepper): add insecure: true to prometheus sink for HTTP URL

### DIFF
--- a/docker-compose/data-prepper/pipelines.template.yaml
+++ b/docker-compose/data-prepper/pipelines.template.yaml
@@ -142,6 +142,7 @@ service-metrics-cortex-pipeline:
     # Cortex's distributor push endpoint is /api/v1/push (not Prometheus's /api/v1/write).
     - prometheus:
         url: "http://PROMETHEUS_HOST:PROMETHEUS_PORT/api/v1/push"
+        insecure: true
         threshold:
           max_events: 500
           flush_interval: 5s


### PR DESCRIPTION
### Description
 - Data Prepper 2.16.0 requires insecure: true when using HTTP (non-HTTPS) URLs in the prometheus sink plugin
 - Without this flag, the service-metrics-cortex-pipeline fails validation on startup, causing Data Prepper to exit with "No valid pipeline is available for execution"
 - Both e2e tests (test/e2e.sh and test/e2e-install.sh) pass with this fix

### Test plan

  - test/e2e.sh — full compose stack up, health checks, trace verified in OpenSearch
  - test/e2e-install.sh — install flow end-to-end, same checks pass



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
