### PR TITLE
fix: deduplicate index patterns in dashboards init and pin otel-demo to 2.2.0

### DIFF
--- a/.env
+++ b/.env
@@ -99,7 +99,7 @@ EVAL_CANARY_LOOKBACK_MINUTES=15
 # Demo App version
 IMAGE_VERSION=2.2.0
 IMAGE_NAME=ghcr.io/open-telemetry/demo
-DEMO_VERSION=latest
+DEMO_VERSION=2.2.0
 
 # Build Args
 TRACETEST_IMAGE_VERSION=v1.7.1
@@ -257,10 +257,6 @@ GRAFANA_HOST=grafana
 JAEGER_HOST=jaeger
 JAEGER_UI_PORT=16686
 JAEGER_GRPC_PORT=4317
-
-# Telemetry Docs (referenced by frontend-proxy envoy template)
-TELEMETRY_DOCS_HOST=otel-collector
-TELEMETRY_DOCS_PORT=4318
 
 # Java Options (workaround for OSX JDK bug)
 _JAVA_OPTIONS=

--- a/docker-compose.otel-demo.yml
+++ b/docker-compose.otel-demo.yml
@@ -349,8 +349,6 @@ services:
       - FLAGD_PORT
       - FLAGD_UI_HOST
       - FLAGD_UI_PORT
-      - TELEMETRY_DOCS_HOST
-      - TELEMETRY_DOCS_PORT
     depends_on:
       frontend:
         condition: service_started

--- a/docker-compose/opensearch-dashboards/init/init-opensearch-dashboards.py
+++ b/docker-compose/opensearch-dashboards/init/init-opensearch-dashboards.py
@@ -1629,13 +1629,17 @@ def _create_saved_object_directly(workspace_id, obj):
         return False
 
 
-def import_ndjson_dashboard(workspace_id, ndjson_path):
+def import_ndjson_dashboard(workspace_id, ndjson_path, id_mappings=None):
     """Import a dashboard and its dependencies from an ndjson export file.
 
     Objects that reference virtual index patterns (e.g. Prometheus datasource)
     are separated out and created individually via the saved-objects API, which
     does not validate references. The remaining objects are bulk-imported via the
     _import API.
+
+    id_mappings: optional dict of {old_id: new_id} to rewrite references at
+    import time. Used to point exported objects at the live index-pattern IDs
+    instead of the hardcoded ones from the export environment.
     """
     import json
     import io
@@ -1663,10 +1667,21 @@ def import_ndjson_dashboard(workspace_id, ndjson_path):
         # Skip the export summary line (has exportedCount but no type)
         if "exportedCount" in obj and "type" not in obj:
             continue
+        # Skip index-pattern objects — they are created earlier by the init
+        # script with the correct workspace/datasource associations. Importing
+        # them again from the ndjson would create duplicates with different IDs.
+        if obj.get("type") == "index-pattern":
+            continue
         # Remove workspace associations so objects land in the target workspace
         obj.pop("workspaces", None)
         # Remove version field that can cause conflicts on import
         obj.pop("version", None)
+
+        # Rewrite references to point at the live index-pattern IDs
+        if id_mappings:
+            for ref in obj.get("references", []):
+                if ref.get("id") in id_mappings:
+                    ref["id"] = id_mappings[ref["id"]]
 
         if _has_virtual_reference(obj):
             direct_create.append(obj)
@@ -1769,8 +1784,15 @@ def main():
     prometheus_datasource_id = create_prometheus_datasource(workspace_id)
     create_opensearch_datasource(workspace_id)
 
-    # Import Astronomy Shop dashboard (ndjson export with all dependencies)
-    import_ndjson_dashboard(workspace_id, "/config/dashboard-astronomy-shop.ndjson")
+    # Import Astronomy Shop dashboard (ndjson export with all dependencies).
+    # Map the hardcoded index-pattern IDs from the export to the live IDs
+    # created above, so dashboard panels reference the correct datasets.
+    ndjson_id_mappings = {}
+    if logs_pattern_id:
+        ndjson_id_mappings["545c7990-2938-11f1-84ad-e734b5ac5a91"] = logs_pattern_id
+    if traces_pattern_id:
+        ndjson_id_mappings["54f4c1f0-2938-11f1-84ad-e734b5ac5a91"] = traces_pattern_id
+    import_ndjson_dashboard(workspace_id, "/config/dashboard-astronomy-shop.ndjson", ndjson_id_mappings)
 
     # Create saved queries for common agent observability patterns
     create_default_saved_queries(workspace_id)

--- a/docker-compose/opensearch-dashboards/init/init-opensearch-dashboards.py
+++ b/docker-compose/opensearch-dashboards/init/init-opensearch-dashboards.py
@@ -1821,5 +1821,90 @@ def main():
     print(f"📈 Prometheus: http://localhost:{PROMETHEUS_PORT}")
     print()
 
+def refresh_index_pattern_fields(workspace_id, pattern_id, title):
+    """Refresh the fields list for an index pattern by querying OpenSearch mappings.
+
+    OSD populates fields lazily on first Discover/Explore visit. This function
+    triggers the same refresh via the API so field lists are available immediately.
+    """
+    if not pattern_id:
+        return False
+
+    if workspace_id and workspace_id != "default":
+        url = f"{BASE_URL}/w/{workspace_id}/api/index_patterns/_fields_for_wildcard?pattern={title}&meta_fields=_source&meta_fields=_id&meta_fields=_type&meta_fields=_index&meta_fields=_score"
+    else:
+        url = f"{BASE_URL}/api/index_patterns/_fields_for_wildcard?pattern={title}&meta_fields=_source&meta_fields=_id&meta_fields=_type&meta_fields=_index&meta_fields=_score"
+
+    try:
+        resp = requests.get(
+            url, auth=(USERNAME, PASSWORD),
+            headers={"Content-Type": "application/json", "osd-xsrf": "true"},
+            verify=False, timeout=30,
+        )
+        if resp.status_code != 200:
+            print(f"  ⚠️  Failed to fetch fields for {title}: {resp.status_code}")
+            return False
+
+        fields = resp.json().get("fields", [])
+        if not fields:
+            print(f"  ⏭️  No fields found for {title} (index may be empty)")
+            return False
+
+        import json
+        fields_json = json.dumps(fields)
+
+        if workspace_id and workspace_id != "default":
+            put_url = f"{BASE_URL}/w/{workspace_id}/api/saved_objects/index-pattern/{pattern_id}"
+        else:
+            put_url = f"{BASE_URL}/api/saved_objects/index-pattern/{pattern_id}"
+
+        put_resp = requests.put(
+            put_url, auth=(USERNAME, PASSWORD),
+            headers={"Content-Type": "application/json", "osd-xsrf": "true"},
+            json={"attributes": {"fields": fields_json}},
+            verify=False, timeout=10,
+        )
+        if put_resp.status_code == 200:
+            print(f"  ✅ Refreshed fields for {title} ({len(fields)} fields)")
+            return True
+        else:
+            print(f"  ⚠️  Failed to update fields for {title}: {put_resp.status_code}")
+            return False
+    except requests.exceptions.RequestException as e:
+        print(f"  ⚠️  Error refreshing fields for {title}: {e}")
+        return False
+
+
+def delayed_field_refresh(workspace_id, patterns):
+    """Wait for data to land in indices, then refresh field lists.
+
+    Called after the main init completes. Waits 10 minutes for the otel-demo
+    and agent examples to populate indices with representative documents so
+    the field refresh picks up all mapped fields.
+    """
+    delay_minutes = 10
+    print(f"\n⏳ Waiting {delay_minutes} minutes for indices to populate before refreshing fields...")
+    time.sleep(delay_minutes * 60)
+
+    print("🔄 Refreshing index pattern field lists...")
+    for pattern_id, title in patterns:
+        refresh_index_pattern_fields(workspace_id, pattern_id, title)
+    print("✅ Field refresh complete")
+
+
 if __name__ == "__main__":
     main()
+
+    # Re-read workspace and pattern IDs for the delayed refresh.
+    # main() already printed success, so this is a background follow-up.
+    workspace_id = get_existing_workspace()
+    logs_id = get_existing_index_pattern(workspace_id, "logs-otel-v1*")
+    traces_id = get_existing_index_pattern(workspace_id, "otel-v1-apm-span*")
+    svc_map_id = get_existing_index_pattern(workspace_id, "otel-v2-apm-service-map*")
+
+    patterns = [
+        (logs_id, "logs-otel-v1*"),
+        (traces_id, "otel-v1-apm-span*"),
+        (svc_map_id, "otel-v2-apm-service-map*"),
+    ]
+    delayed_field_refresh(workspace_id, patterns)


### PR DESCRIPTION
## Summary

- **Fix duplicate index patterns**: The ndjson dashboard import was creating duplicate index-pattern saved objects because the exported file contained hardcoded index-pattern entries with different IDs than the ones the init script creates. Now the import skips `index-pattern` type objects from ndjson and rewrites references in dashboard/explore panels to point at the live IDs.
- **Pin otel-demo to 2.2.0**: The `latest` tag has a broken `ad` service (gRPC `AbstractMethodError` from a 1.81.0 incompatibility) and the `frontend-proxy` expects `FIREPIT_HOST`/`TELEMETRY_DOCS_HOST` env vars that were added after 2.2.0.
- **Refresh index pattern fields after 10-minute delay**: After the main init completes, waits 10 minutes for indices to populate, then refreshes the field lists via the OSD API so Explore/Discover show fields without requiring a manual browser visit.

## Test plan

- [x] `docker compose up -d` with otel-demo enabled — all 37 services healthy
- [x] Verified 3 index patterns created (no duplicates)
- [x] Traces (4k+) and logs (2k+) flowing into OpenSearch
- [x] Cortex receiving metrics (`up{job="otel-collector"} = 1`)
- [x] `ad` service stable with 2.2.0 tag (was crash-looping with `latest`)
- [x] `frontend-proxy` stable without `TELEMETRY_DOCS_*` / `FIREPIT_*` env vars
- [x] Delayed field refresh queued (10-minute timer running in init container)