### PR TITLE
fix(helm): sync chart with compose, Cortex dashboard queries, external-dns safety

### DIFF
--- a/.env
+++ b/.env
@@ -11,7 +11,10 @@ INCLUDE_COMPOSE_EXAMPLES=docker-compose.examples.yml
 INCLUDE_COMPOSE_LOCAL_OPENSEARCH=docker-compose.local-opensearch.yml
 INCLUDE_COMPOSE_LOCAL_OPENSEARCH_DASHBOARDS=docker-compose.local-opensearch-dashboards.yml
 
-OPENSEARCH_DOCKER_REPO=opensearchstaging
+# TODO: Change to opensearchproject after 3.7.0 official release
+# OPENSEARCH_DOCKER_REPO=opensearchstaging
+OPENSEARCH_IMAGE=ashisagr32966/opensearch-sql-main:3.7.0-sql-main
+OPENSEARCH_DASHBOARDS_IMAGE=joshuali925/opensearch-dashboards:3.7.0-slos-pr-against-main-v2
 
 
 # OpenSearch Configuration

--- a/charts/observability-stack/Chart.yaml
+++ b/charts/observability-stack/Chart.yaml
@@ -52,6 +52,6 @@ dependencies:
     condition: opentelemetry-collector.enabled
 
   - name: opentelemetry-demo
-    version: "0.40.5"
+    version: "0.40.8"
     repository: "https://open-telemetry.github.io/opentelemetry-helm-charts"
     condition: opentelemetry-demo.enabled

--- a/charts/observability-stack/SYNC.md
+++ b/charts/observability-stack/SYNC.md
@@ -6,10 +6,10 @@ This Helm chart mirrors the Docker Compose configuration for feature parity acro
 
 | Field | Value |
 |-------|-------|
-| **Last synced commit** | `a584256` |
-| **Commit message** | `add  insecure: true flag to connect to cortex/prometheus (#249)` |
+| **Last synced commit** | `6b8b2c8` |
+| **Commit message** | `fix: deduplicate index patterns in dashboards init and pin otel-demo to 2.2.0 (#254)` |
 | **Date** | 2026-05-19 |
-| **Synced by** | @ashisagr |
+| **Synced by** | @ps48 |
 
 ## What Stays in Sync
 

--- a/charts/observability-stack/files/dashboard-pipeline-health.yaml
+++ b/charts/observability-stack/files/dashboard-pipeline-health.yaml
@@ -50,36 +50,26 @@ panels:
     query: "otelcol_processor_batch_metadata_cardinality"
     chartType: line
 
-  # --- Row 5: Prometheus Health ---
-  - id: pipeline-prometheus-ingestion
-    title: "Prometheus Ingestion Rate (chunks/sec)"
-    query: "rate(prometheus_tsdb_head_chunks_created_total[5m])"
+  # --- Row 5: Cortex Health ---
+  - id: pipeline-cortex-ingestion-rate
+    title: "Cortex Ingestion Rate (samples/sec)"
+    query: "avg(cortex_ingester_ingestion_rate_samples_per_second)"
     chartType: line
 
-  - id: pipeline-prometheus-active-series
-    title: "Prometheus Active Time Series"
-    query: "prometheus_tsdb_head_series"
+  - id: pipeline-cortex-active-series
+    title: "Cortex Active Time Series"
+    query: "cortex_ingester_active_series"
     chartType: line
 
-  # --- Row 6: Prometheus Storage ---
-  - id: pipeline-prometheus-wal-size
-    title: "Prometheus WAL Size (bytes)"
-    query: "prometheus_tsdb_wal_storage_size_bytes"
+  # --- Row 6: Cortex Query Performance ---
+  - id: pipeline-cortex-query-latency
+    title: "Cortex Query Latency P99 (sec)"
+    query: "histogram_quantile(0.99, rate(cortex_request_duration_seconds_bucket{route=~\"prometheus_api_v1_query\"}[5m]))"
     chartType: line
 
-  - id: pipeline-prometheus-head-chunks
-    title: "Prometheus Head Chunks Size (bytes)"
-    query: "prometheus_tsdb_head_chunks_storage_size_bytes"
-    chartType: line
-
-  - id: pipeline-prometheus-query-latency
-    title: "Prometheus Query Latency P99 (sec)"
-    query: "histogram_quantile(0.99, rate(prometheus_http_request_duration_seconds_bucket{handler=\"/api/v1/query\"}[5m]))"
-    chartType: line
-
-  - id: pipeline-prometheus-range-query-latency
-    title: "Prometheus Range Query Latency P99 (sec)"
-    query: "histogram_quantile(0.99, rate(prometheus_http_request_duration_seconds_bucket{handler=\"/api/v1/query_range\"}[5m]))"
+  - id: pipeline-cortex-range-query-latency
+    title: "Cortex Range Query Latency P99 (sec)"
+    query: "histogram_quantile(0.99, rate(cortex_request_duration_seconds_bucket{route=~\"prometheus_api_v1_query_range\"}[5m]))"
     chartType: line
 
   # --- Row 7: Data Prepper — Logs Pipeline ---

--- a/charts/observability-stack/files/init-opensearch-dashboards.py
+++ b/charts/observability-stack/files/init-opensearch-dashboards.py
@@ -1700,13 +1700,17 @@ def _create_saved_object_directly(workspace_id, obj):
         return False
 
 
-def import_ndjson_dashboard(workspace_id, ndjson_path):
+def import_ndjson_dashboard(workspace_id, ndjson_path, id_mappings=None):
     """Import a dashboard and its dependencies from an ndjson export file.
 
     Objects that reference virtual index patterns (e.g. Prometheus datasource)
     are separated out and created individually via the saved-objects API, which
     does not validate references. The remaining objects are bulk-imported via the
     _import API.
+
+    id_mappings: optional dict of {old_id: new_id} to rewrite references at
+    import time. Used to point exported objects at the live index-pattern IDs
+    instead of the hardcoded ones from the export environment.
     """
     import json
     import io
@@ -1734,10 +1738,21 @@ def import_ndjson_dashboard(workspace_id, ndjson_path):
         # Skip the export summary line (has exportedCount but no type)
         if "exportedCount" in obj and "type" not in obj:
             continue
+        # Skip index-pattern objects — they are created earlier by the init
+        # script with the correct workspace/datasource associations. Importing
+        # them again from the ndjson would create duplicates with different IDs.
+        if obj.get("type") == "index-pattern":
+            continue
         # Remove workspace associations so objects land in the target workspace
         obj.pop("workspaces", None)
         # Remove version field that can cause conflicts on import
         obj.pop("version", None)
+
+        # Rewrite references to point at the live index-pattern IDs
+        if id_mappings:
+            for ref in obj.get("references", []):
+                if ref.get("id") in id_mappings:
+                    ref["id"] = id_mappings[ref["id"]]
 
         if _has_virtual_reference(obj):
             direct_create.append(obj)
@@ -1847,8 +1862,15 @@ def main():
     prometheus_datasource_id = create_prometheus_datasource(workspace_id)
     create_opensearch_datasource(workspace_id)
 
-    # Import Astronomy Shop dashboard (ndjson export with all dependencies)
-    import_ndjson_dashboard(workspace_id, "/config/dashboard-astronomy-shop.ndjson")
+    # Import Astronomy Shop dashboard (ndjson export with all dependencies).
+    # Map the hardcoded index-pattern IDs from the export to the live IDs
+    # created above, so dashboard panels reference the correct datasets.
+    ndjson_id_mappings = {}
+    if logs_pattern_id:
+        ndjson_id_mappings["545c7990-2938-11f1-84ad-e734b5ac5a91"] = logs_pattern_id
+    if traces_pattern_id:
+        ndjson_id_mappings["54f4c1f0-2938-11f1-84ad-e734b5ac5a91"] = traces_pattern_id
+    import_ndjson_dashboard(workspace_id, "/config/dashboard-astronomy-shop.ndjson", ndjson_id_mappings)
 
     # Create APM config correlation (ties traces + service map + Prometheus)
     if traces_pattern_id and service_map_pattern_id:
@@ -1872,5 +1894,89 @@ def main():
     print(f"📈 Prometheus: http://localhost:{PROMETHEUS_PORT}")
     print()
 
+def refresh_index_pattern_fields(workspace_id, pattern_id, title):
+    """Refresh the fields list for an index pattern by querying OpenSearch mappings.
+
+    OSD populates fields lazily on first Discover/Explore visit. This function
+    triggers the same refresh via the API so field lists are available immediately.
+    """
+    if not pattern_id:
+        return False
+
+    if workspace_id and workspace_id != "default":
+        url = f"{BASE_URL}/w/{workspace_id}/api/index_patterns/_fields_for_wildcard?pattern={title}&meta_fields=_source&meta_fields=_id&meta_fields=_type&meta_fields=_index&meta_fields=_score"
+    else:
+        url = f"{BASE_URL}/api/index_patterns/_fields_for_wildcard?pattern={title}&meta_fields=_source&meta_fields=_id&meta_fields=_type&meta_fields=_index&meta_fields=_score"
+
+    try:
+        resp = requests.get(
+            url, auth=(USERNAME, PASSWORD),
+            headers={"Content-Type": "application/json", "osd-xsrf": "true"},
+            verify=False, timeout=30,
+        )
+        if resp.status_code != 200:
+            print(f"  ⚠️  Failed to fetch fields for {title}: {resp.status_code}")
+            return False
+
+        fields = resp.json().get("fields", [])
+        if not fields:
+            print(f"  ⏭️  No fields found for {title} (index may be empty)")
+            return False
+
+        import json
+        fields_json = json.dumps(fields)
+
+        if workspace_id and workspace_id != "default":
+            put_url = f"{BASE_URL}/w/{workspace_id}/api/saved_objects/index-pattern/{pattern_id}"
+        else:
+            put_url = f"{BASE_URL}/api/saved_objects/index-pattern/{pattern_id}"
+
+        put_resp = requests.put(
+            put_url, auth=(USERNAME, PASSWORD),
+            headers={"Content-Type": "application/json", "osd-xsrf": "true"},
+            json={"attributes": {"fields": fields_json}},
+            verify=False, timeout=10,
+        )
+        if put_resp.status_code == 200:
+            print(f"  ✅ Refreshed fields for {title} ({len(fields)} fields)")
+            return True
+        else:
+            print(f"  ⚠️  Failed to update fields for {title}: {put_resp.status_code}")
+            return False
+    except requests.exceptions.RequestException as e:
+        print(f"  ⚠️  Error refreshing fields for {title}: {e}")
+        return False
+
+
+def delayed_field_refresh(workspace_id, patterns):
+    """Wait for data to land in indices, then refresh field lists.
+
+    Called after the main init completes. Waits 10 minutes for the otel-demo
+    and agent examples to populate indices with representative documents so
+    the field refresh picks up all mapped fields.
+    """
+    delay_minutes = 10
+    print(f"\n⏳ Waiting {delay_minutes} minutes for indices to populate before refreshing fields...")
+    time.sleep(delay_minutes * 60)
+
+    print("🔄 Refreshing index pattern field lists...")
+    for pattern_id, title in patterns:
+        refresh_index_pattern_fields(workspace_id, pattern_id, title)
+    print("✅ Field refresh complete")
+
+
 if __name__ == "__main__":
     main()
+
+    # Re-read workspace and pattern IDs for the delayed refresh.
+    workspace_id = get_existing_workspace()
+    logs_id = get_existing_index_pattern(workspace_id, "logs-otel-v1*")
+    traces_id = get_existing_index_pattern(workspace_id, "otel-v1-apm-span*")
+    svc_map_id = get_existing_index_pattern(workspace_id, "otel-v2-apm-service-map*")
+
+    patterns = [
+        (logs_id, "logs-otel-v1*"),
+        (traces_id, "otel-v1-apm-span*"),
+        (svc_map_id, "otel-v2-apm-service-map*"),
+    ]
+    delayed_field_refresh(workspace_id, patterns)

--- a/charts/observability-stack/templates/otel-collector-configmap.yaml
+++ b/charts/observability-stack/templates/otel-collector-configmap.yaml
@@ -54,6 +54,71 @@ data:
               relabel_configs:
                 - target_label: service.name
                   replacement: frontend-proxy
+      # OpenSearch exporter metrics for the OS Cluster Health dashboard.
+      prometheus/opensearch-exporter:
+        config:
+          scrape_configs:
+            - job_name: opensearch-exporter
+              scrape_interval: 15s
+              static_configs:
+                - targets: ["{{ include "observability-stack.fullname" . }}-opensearch-exporter:9114"]
+              relabel_configs:
+                - target_label: service.name
+                  replacement: opensearch-exporter
+      # Cortex internal metrics for the Pipeline Health dashboard.
+      prometheus/cortex:
+        config:
+          scrape_configs:
+            - job_name: cortex
+              scrape_interval: 15s
+              metrics_path: /metrics
+              static_configs:
+                - targets: ["{{ .Release.Name }}-prometheus-server:80"]
+              relabel_configs:
+                - target_label: service.name
+                  replacement: cortex
+      # Data Prepper pipeline metrics for the Pipeline Health dashboard.
+      prometheus/data-prepper:
+        config:
+          scrape_configs:
+            - job_name: data-prepper
+              scrape_interval: 15s
+              metrics_path: /metrics/sys
+              static_configs:
+                - targets: ["{{ .Release.Name }}-data-prepper:4900"]
+              relabel_configs:
+                - target_label: service.name
+                  replacement: data-prepper
+            - job_name: data-prepper-pipelines
+              scrape_interval: 15s
+              metrics_path: /metrics/prometheus
+              static_configs:
+                - targets: ["{{ .Release.Name }}-data-prepper:4900"]
+              relabel_configs:
+                - target_label: service.name
+                  replacement: data-prepper
+      # Kubernetes metrics — harmless no-op if kube-state-metrics / node-exporter
+      # are not installed (DNS NXDOMAIN → scrape drops silently).
+      prometheus/kube-state-metrics:
+        config:
+          scrape_configs:
+            - job_name: kube-state-metrics
+              scrape_interval: 15s
+              static_configs:
+                - targets: ["kube-state-metrics.kube-system.svc.cluster.local:8080"]
+              relabel_configs:
+                - target_label: service.name
+                  replacement: kube-state-metrics
+      prometheus/node-exporter:
+        config:
+          scrape_configs:
+            - job_name: node-exporter
+              scrape_interval: 15s
+              static_configs:
+                - targets: ["node-exporter-prometheus-node-exporter.kube-system.svc.cluster.local:9100"]
+              relabel_configs:
+                - target_label: service.name
+                  replacement: node-exporter
     processors:
       memory_limiter:
         check_interval: 5s
@@ -143,7 +208,7 @@ data:
           processors: [resourcedetection, memory_limiter, transform, batch]
           exporters: [otlp/opensearch, debug]
         metrics:
-          receivers: [otlp, prometheus/self, prometheus/envoy]
+          receivers: [otlp, prometheus/self, prometheus/envoy, prometheus/opensearch-exporter, prometheus/cortex, prometheus/data-prepper, prometheus/kube-state-metrics, prometheus/node-exporter]
           processors: [resourcedetection, memory_limiter, batch]
           exporters: [prometheusremotewrite/cortex, debug]
         logs:

--- a/charts/observability-stack/templates/otel-demo-alerting-rules-monitors-init-job.yaml
+++ b/charts/observability-stack/templates/otel-demo-alerting-rules-monitors-init-job.yaml
@@ -4,7 +4,7 @@
 #   1. Cortex ruler rules from /rules/otel_demo
 #   2. OpenSearch alerting monitors for OTel Demo traces/logs
 #      (checkout, payment, cart, frontend RED signals)
-# Mirrors the `otel-demo-alerting-rules-monitors-init` container in
+# Mirrors the `otel-demo-alerts-init` container in
 # docker-compose.otel-demo.yml. Named separately from the base Job (rather
 # than overlaying its volume mounts) because Helm doesn't support
 # subchart-style service overlays — and the upstream API is idempotent
@@ -12,7 +12,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "observability-stack.fullname" . }}-otel-demo-alerting-rules-monitors-init-script
+  name: {{ include "observability-stack.fullname" . }}-otel-demo-alerts-init-script
   labels:
     {{- include "observability-stack.labels" . | nindent 4 }}
     app.kubernetes.io/component: init
@@ -29,7 +29,7 @@ data:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "observability-stack.fullname" . }}-otel-demo-alerting-rules-monitors-init
+  name: {{ include "observability-stack.fullname" . }}-otel-demo-alerts-init
   labels:
     {{- include "observability-stack.labels" . | nindent 4 }}
     app.kubernetes.io/component: init
@@ -42,11 +42,11 @@ spec:
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: otel-demo-alerting-rules-monitors-init
+        app.kubernetes.io/name: otel-demo-alerts-init
     spec:
       restartPolicy: OnFailure
       containers:
-        - name: otel-demo-alerting-rules-monitors-init
+        - name: otel-demo-alerts-init
           image: python:3.11-alpine
           command:
             - /bin/sh
@@ -82,7 +82,7 @@ spec:
       volumes:
         - name: script
           configMap:
-            name: {{ include "observability-stack.fullname" . }}-otel-demo-alerting-rules-monitors-init-script
+            name: {{ include "observability-stack.fullname" . }}-otel-demo-alerts-init-script
         - name: rules-otel-demo
           configMap:
             name: {{ include "observability-stack.fullname" . }}-cortex-rules-otel-demo

--- a/charts/observability-stack/tests/otel_collector_configmap_test.yaml
+++ b/charts/observability-stack/tests/otel_collector_configmap_test.yaml
@@ -51,7 +51,7 @@ tests:
     asserts:
       - matchRegex:
           path: data.relay
-          pattern: "receivers:\\s*\\[otlp,\\s*prometheus/self,\\s*prometheus/envoy\\]"
+          pattern: "receivers:\\s*\\[otlp,\\s*prometheus/self,\\s*prometheus/envoy,\\s*prometheus/opensearch-exporter,\\s*prometheus/cortex,\\s*prometheus/data-prepper,\\s*prometheus/kube-state-metrics,\\s*prometheus/node-exporter\\]"
       - matchRegex:
           path: data.relay
           pattern: "exporters:\\s*\\[prometheusremotewrite/cortex,\\s*debug\\]"

--- a/charts/observability-stack/values-anonymous-auth.yaml
+++ b/charts/observability-stack/values-anonymous-auth.yaml
@@ -184,6 +184,9 @@ opensearch-dashboards:
       datasetManagement.enabled: true
       data.savedQueriesNewUI.enabled: true
       opensearchDashboards.branding.useExpandedHeader: false
+      opensearchDashboards.enableIconSideNav: true
+      observability.alertManager.enabled: true
+      observability.slo.enabled: true
       uiSettings.overrides.home:useNewHomePage: true
       uiSettings.overrides.query:enhancements:enabled: true
       uiSettings.overrides.explore:experimental: true

--- a/charts/observability-stack/values.yaml
+++ b/charts/observability-stack/values.yaml
@@ -12,6 +12,7 @@ opensearch:
   enabled: true
   singleNode: false
   replicas: 3
+  # TODO: Change to opensearchproject/opensearch after 3.7.0 official release
   image:
     repository: "ashisagr32966/opensearch-sql-main"
     tag: "3.7.0-sql-main"
@@ -76,9 +77,10 @@ opensearch:
 opensearch-dashboards:
   enabled: true
   replicaCount: 3
+  # TODO: Change to opensearchproject/opensearch-dashboards after 3.7.0 official release
   image:
     repository: "joshuali925/opensearch-dashboards"
-    tag: "3.7.0-slos-followups-on-main-v2"
+    tag: "3.7.0-slos-pr-against-main-v2"
   resources:
     requests:
       cpu: "500m"

--- a/charts/observability-stack/values.yaml
+++ b/charts/observability-stack/values.yaml
@@ -13,8 +13,8 @@ opensearch:
   singleNode: false
   replicas: 3
   image:
-    repository: "opensearchstaging/opensearch"
-    tag: "3.7.0"
+    repository: "ashisagr32966/opensearch-sql-main"
+    tag: "3.7.0-sql-main"
   resources:
     requests:
       memory: "4Gi"
@@ -77,8 +77,8 @@ opensearch-dashboards:
   enabled: true
   replicaCount: 3
   image:
-    repository: "opensearchstaging/opensearch-dashboards"
-    tag: "3.7.0"
+    repository: "joshuali925/opensearch-dashboards"
+    tag: "3.7.0-slos-followups-on-main-v2"
   resources:
     requests:
       cpu: "500m"

--- a/docker-compose.local-opensearch-dashboards.yml
+++ b/docker-compose.local-opensearch-dashboards.yml
@@ -12,7 +12,8 @@ x-default-logging: &logging
 services:
   # OpenSearch Dashboards - Web UI for visualizing logs and traces
   opensearch-dashboards:
-    image: ${OPENSEARCH_DOCKER_REPO}/opensearch-dashboards:${OPENSEARCH_DASHBOARDS_VERSION}
+    image: ${OPENSEARCH_DASHBOARDS_IMAGE}
+    platform: linux/amd64
     container_name: opensearch-dashboards
     pull_policy: always
     command: >

--- a/docker-compose.local-opensearch.yml
+++ b/docker-compose.local-opensearch.yml
@@ -16,7 +16,7 @@ volumes:
 services:
   # OpenSearch - Stores and indexes logs and traces for search and analysis
   opensearch:
-    image: ${OPENSEARCH_DOCKER_REPO}/opensearch:${OPENSEARCH_VERSION}
+    image: ${OPENSEARCH_IMAGE}
     container_name: opensearch
     pull_policy: always
     environment:

--- a/docker-compose/opensearch-dashboards/dashboard-pipeline-health.yaml
+++ b/docker-compose/opensearch-dashboards/dashboard-pipeline-health.yaml
@@ -1,112 +1,132 @@
 # Observability Pipeline Health Dashboard — OTel Collector and Prometheus self-monitoring
+
 dashboard:
   id: observability-pipeline-health-dashboard
   title: Observability Pipeline Health
   description: OTel Collector throughput, Prometheus ingestion, and pipeline health
+
 panels:
   # --- Row 1: OTel Collector Throughput ---
   - id: pipeline-otel-spans-received
     title: "OTel Spans Received/sec"
     query: "rate(otelcol_receiver_accepted_spans_total[5m])"
     chartType: line
+
   - id: pipeline-otel-spans-exported
     title: "OTel Spans Exported/sec"
     query: "rate(otelcol_exporter_sent_spans_total[5m])"
     chartType: line
+
   # --- Row 2: OTel Metrics & Failures ---
   - id: pipeline-otel-metrics-received
     title: "OTel Metrics Received/sec"
     query: "rate(otelcol_receiver_accepted_metric_points_total[5m])"
     chartType: line
+
   - id: pipeline-otel-spans-dropped
     title: "OTel Spans Dropped/sec"
     query: "rate(otelcol_exporter_send_failed_spans_total[5m])"
     chartType: line
+
   # --- Row 3: OTel Collector Resources ---
   - id: pipeline-otel-queue-size
     title: "OTel Exporter Queue Size"
     query: "otelcol_exporter_queue_size"
     chartType: line
+
   - id: pipeline-otel-collector-memory
     title: "OTel Collector Memory (bytes)"
     query: "otelcol_process_memory_rss_bytes"
     chartType: line
+
   # --- Row 4: OTel Collector CPU & Uptime ---
   - id: pipeline-otel-collector-cpu
     title: "OTel Collector CPU Usage"
     query: "rate(otelcol_process_cpu_seconds_total[5m])"
     chartType: line
+
   - id: pipeline-otel-batch-cardinality
     title: "OTel Batch Metadata Cardinality"
     query: "otelcol_processor_batch_metadata_cardinality"
     chartType: line
-  # --- Row 5: Prometheus Health ---
-  - id: pipeline-prometheus-ingestion
-    title: "Prometheus Ingestion Rate (chunks/sec)"
-    query: "rate(prometheus_tsdb_head_chunks_created_total[5m])"
+
+  # --- Row 5: Cortex Health ---
+  - id: pipeline-cortex-ingestion-rate
+    title: "Cortex Ingestion Rate (samples/sec)"
+    query: "avg(cortex_ingester_ingestion_rate_samples_per_second)"
     chartType: line
-  - id: pipeline-prometheus-active-series
-    title: "Prometheus Active Time Series"
-    query: "prometheus_tsdb_head_series"
+
+  - id: pipeline-cortex-active-series
+    title: "Cortex Active Time Series"
+    query: "cortex_ingester_active_series"
     chartType: line
-  # --- Row 6: Prometheus Storage ---
-  - id: pipeline-prometheus-wal-size
-    title: "Prometheus WAL Size (bytes)"
-    query: "prometheus_tsdb_wal_storage_size_bytes"
+
+  # --- Row 6: Cortex Query Performance ---
+  - id: pipeline-cortex-query-latency
+    title: "Cortex Query Latency P99 (sec)"
+    query: "histogram_quantile(0.99, rate(cortex_request_duration_seconds_bucket{route=~\"prometheus_api_v1_query\"}[5m]))"
     chartType: line
-  - id: pipeline-prometheus-head-chunks
-    title: "Prometheus Head Chunks Size (bytes)"
-    query: "prometheus_tsdb_head_chunks_storage_size_bytes"
+
+  - id: pipeline-cortex-range-query-latency
+    title: "Cortex Range Query Latency P99 (sec)"
+    query: "histogram_quantile(0.99, rate(cortex_request_duration_seconds_bucket{route=~\"prometheus_api_v1_query_range\"}[5m]))"
     chartType: line
-  - id: pipeline-prometheus-query-latency
-    title: "Prometheus Query Latency P99 (sec)"
-    query: "histogram_quantile(0.99, rate(prometheus_http_request_duration_seconds_bucket{handler=\"/api/v1/query\"}[5m]))"
-    chartType: line
+
   # --- Row 7: Data Prepper — Logs Pipeline ---
   - id: pipeline-dp-logs-processed
     title: "DP Logs Processed/sec"
     query: "rate(otel_logs_pipeline_recordsProcessed_total[5m])"
     chartType: line
+
   - id: pipeline-dp-logs-latency
     title: "DP Logs Pipeline Latency (avg sec)"
     query: "rate(otel_logs_pipeline_opensearch_PipelineLatency_seconds_sum[5m]) / rate(otel_logs_pipeline_opensearch_PipelineLatency_seconds_count[5m])"
     chartType: line
+
   # --- Row 8: Data Prepper — Traces Pipeline ---
   - id: pipeline-dp-traces-processed
     title: "DP Traces Processed/sec"
     query: "rate(otel_traces_pipeline_recordsProcessed_total[5m])"
     chartType: line
+
   - id: pipeline-dp-traces-latency
     title: "DP Traces Pipeline Latency (avg sec)"
     query: "rate(traces_raw_pipeline_opensearch_PipelineLatency_seconds_sum[5m]) / rate(traces_raw_pipeline_opensearch_PipelineLatency_seconds_count[5m])"
     chartType: line
+
   # --- Row 9: Data Prepper — Metrics Pipeline ---
   - id: pipeline-dp-metrics-received
     title: "DP Metrics Received/sec"
     query: "rate(otlp_metrics_requestsReceived_total[5m])"
     chartType: line
+
   - id: pipeline-dp-otlp-requests
     title: "DP OTLP Requests Received/sec (all)"
     query: "rate(otlp_traces_requestsReceived_total[5m]) + rate(otlp_logs_requestsReceived_total[5m]) + rate(otlp_metrics_requestsReceived_total[5m])"
     chartType: line
+
   # --- Row 10: Data Prepper — Writes & Errors ---
   - id: pipeline-dp-logs-docs-written
     title: "DP Logs Docs Written/sec"
     query: "rate(otel_logs_pipeline_opensearch_documentsSuccess_total[5m])"
     chartType: line
+
   - id: pipeline-dp-traces-docs-written
     title: "DP Traces Docs Written/sec"
     query: "rate(traces_raw_pipeline_opensearch_documentsSuccess_total[5m])"
     chartType: line
+
   # --- Row 11: Data Prepper — Errors & Buffer ---
   - id: pipeline-dp-bulk-errors
     title: "DP Bulk Request Errors"
     query: "sum(rate(otel_logs_pipeline_opensearch_bulkRequestErrors_total[5m])) + sum(rate(traces_raw_pipeline_opensearch_bulkRequestErrors_total[5m]))"
     chartType: line
+
   - id: pipeline-dp-buffer-usage
     title: "DP Buffer Writes/sec"
     query: "rate(otel_logs_pipeline_BlockingBuffer_recordsWritten_total[5m]) + rate(otel_traces_pipeline_BlockingBuffer_recordsWritten_total[5m])"
     chartType: line
+
   - id: pipeline-dp-buffer-capacity
     title: "DP Buffer Capacity Used %"
     query: "otlp_pipeline_BlockingBuffer_capacityUsed + otel_logs_pipeline_BlockingBuffer_capacityUsed + otel_traces_pipeline_BlockingBuffer_capacityUsed"

--- a/terraform/aws/addons.tf
+++ b/terraform/aws/addons.tf
@@ -52,16 +52,40 @@ resource "helm_release" "external_dns" {
   }
   set {
     name  = "domainFilters[0]"
-    value = data.aws_route53_zone.this[0].name
+    value = var.domain
   }
   set {
     name  = "policy"
-    value = "sync"
+    value = "upsert-only"
   }
   set {
     name  = "txtOwnerId"
     value = var.cluster_name
   }
+
+  depends_on = [module.eks]
+}
+
+# --- kube-state-metrics (K8s Cluster Health dashboard) ---
+
+resource "helm_release" "kube_state_metrics" {
+  name       = "kube-state-metrics"
+  repository = "https://prometheus-community.github.io/helm-charts"
+  chart      = "kube-state-metrics"
+  namespace  = "kube-system"
+  version    = "5.28.0"
+
+  depends_on = [module.eks]
+}
+
+# --- node-exporter (K8s Cluster Health dashboard) ---
+
+resource "helm_release" "node_exporter" {
+  name       = "node-exporter"
+  repository = "https://prometheus-community.github.io/helm-charts"
+  chart      = "prometheus-node-exporter"
+  namespace  = "kube-system"
+  version    = "4.43.1"
 
   depends_on = [module.eks]
 }

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -207,3 +207,4 @@ provider "helm" {
     }
   }
 }
+


### PR DESCRIPTION
## Summary

- **Helm chart init script sync**: Ports ndjson index-pattern dedup fix and delayed field refresh from compose (#254)
- **Dashboard pipeline health**: Replace Prometheus TSDB queries with Cortex equivalents (`cortex_ingester_*`), remove WAL/Head Chunks panels (no Cortex equivalent)
- **Job name fix**: Shorten `otel-demo-alerting-rules-monitors-init` → `otel-demo-alerts-init` to fix K8s 63-char label limit
- **OSD config flags**: Add `enableIconSideNav`, `observability.alertManager.enabled`, `observability.slo.enabled` to `values-anonymous-auth.yaml`
- **External-dns safety**: Scope `domainFilters` to `var.domain` (not entire zone) and use `upsert-only` policy to prevent accidental overwrites of unrelated DNS records
- **Bump otel-demo subchart**: 0.40.5 → 0.40.8 (appVersion 2.2.0)

## Test plan

- [x] Deployed to EKS — all pods healthy
- [x] Cortex dashboard panels showing data (ingestion rate, active series, query latency)
- [x] Data Prepper pipeline panels showing data
- [x] OpenSearch Cluster Health dashboard working
- [x] Kubernetes Cluster Health dashboard working
- [x] SLO flag, icon nav, and alertManager UI confirmed working
- [x] `helm lint` + `helm unittest` — 73 tests pass