### PR TITLE
Fix Prometheus image link to point to discover-metrics page

### DIFF
--- a/docs/src/components/CompetitorComparison.astro
+++ b/docs/src/components/CompetitorComparison.astro
@@ -44,7 +44,7 @@ const showcaseItems: ShowcaseItem[] = [
     description: 'PromQL-powered metrics dashboards with custom panels, alerting, and auto-computed RED metrics.',
     image: '/images/dashboards/prometheus.png',
     alt: 'Prometheus metrics dashboard',
-    link: '/docs/dashboards/',
+    link: '/docs/investigate/discover-metrics/',
   },
   {
     title: 'Cross-Signal Correlation',


### PR DESCRIPTION
### Description

The Prometheus metrics image in the `CompetitorComparison` component was linking to `/docs/dashboards/` which is incorrect. Updated the link to `/docs/investigate/discover-metrics/` so clicking the image navigates to the correct page.

### Issues Resolved

Resolves #263

### Changes

- Updated `link` in `docs/src/components/CompetitorComparison.astro` from `/docs/dashboards/` to `/docs/investigate/discover-metrics/`