### PR TITLE
fix: use opensearchstaging 3.7.0 images for OS and OSD

### DIFF
--- a/.env
+++ b/.env
@@ -12,9 +12,7 @@ INCLUDE_COMPOSE_LOCAL_OPENSEARCH=docker-compose.local-opensearch.yml
 INCLUDE_COMPOSE_LOCAL_OPENSEARCH_DASHBOARDS=docker-compose.local-opensearch-dashboards.yml
 
 # TODO: Change to opensearchproject after 3.7.0 official release
-# OPENSEARCH_DOCKER_REPO=opensearchstaging
-OPENSEARCH_IMAGE=ashisagr32966/opensearch-sql-main:3.7.0-sql-main
-OPENSEARCH_DASHBOARDS_IMAGE=joshuali925/opensearch-dashboards:3.7.0-slos-pr-against-main-v2
+OPENSEARCH_DOCKER_REPO=opensearchstaging
 
 
 # OpenSearch Configuration

--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -24,7 +24,7 @@ jobs:
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
 
       - name: Install helm-unittest plugin
-        run: helm plugin install https://github.com/helm-unittest/helm-unittest.git --verify=false
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest.git
 
       - name: Run helm lint + unittest
         run: ./test/helm-test.sh

--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -22,6 +22,8 @@ jobs:
 
       - name: Set up Helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
+        with:
+          version: v3.18.6
 
       - name: Install helm-unittest plugin
         run: helm plugin install https://github.com/helm-unittest/helm-unittest.git

--- a/charts/observability-stack/values.yaml
+++ b/charts/observability-stack/values.yaml
@@ -14,8 +14,8 @@ opensearch:
   replicas: 3
   # TODO: Change to opensearchproject/opensearch after 3.7.0 official release
   image:
-    repository: "ashisagr32966/opensearch-sql-main"
-    tag: "3.7.0-sql-main"
+    repository: "opensearchstaging/opensearch"
+    tag: "3.7.0"
   resources:
     requests:
       memory: "4Gi"
@@ -79,8 +79,8 @@ opensearch-dashboards:
   replicaCount: 3
   # TODO: Change to opensearchproject/opensearch-dashboards after 3.7.0 official release
   image:
-    repository: "joshuali925/opensearch-dashboards"
-    tag: "3.7.0-slos-pr-against-main-v2"
+    repository: "opensearchstaging/opensearch-dashboards"
+    tag: "3.7.0"
   resources:
     requests:
       cpu: "500m"

--- a/docker-compose.local-opensearch-dashboards.yml
+++ b/docker-compose.local-opensearch-dashboards.yml
@@ -12,7 +12,7 @@ x-default-logging: &logging
 services:
   # OpenSearch Dashboards - Web UI for visualizing logs and traces
   opensearch-dashboards:
-    image: ${OPENSEARCH_DASHBOARDS_IMAGE}
+    image: ${OPENSEARCH_DOCKER_REPO}/opensearch-dashboards:${OPENSEARCH_DASHBOARDS_VERSION}
     platform: linux/amd64
     container_name: opensearch-dashboards
     pull_policy: always

--- a/docker-compose.local-opensearch.yml
+++ b/docker-compose.local-opensearch.yml
@@ -16,7 +16,7 @@ volumes:
 services:
   # OpenSearch - Stores and indexes logs and traces for search and analysis
   opensearch:
-    image: ${OPENSEARCH_IMAGE}
+    image: ${OPENSEARCH_DOCKER_REPO}/opensearch:${OPENSEARCH_VERSION}
     container_name: opensearch
     pull_policy: always
     environment:

--- a/install.sh
+++ b/install.sh
@@ -849,8 +849,8 @@ run_simulated_installer() {
 
     # Demo image list
     local images=(
-        "opensearchproject/opensearch:3.5.0"
-        "opensearchproject/opensearch-dashboards:3.5.0"
+        "opensearchstaging/opensearch:3.7.0"
+        "opensearchstaging/opensearch-dashboards:3.7.0"
         "otel/opentelemetry-collector-contrib:0.143.0"
         "opensearchproject/data-prepper:2.13.0"
         "prom/prometheus:v3.8.1"


### PR DESCRIPTION
## Summary
- Revert to the original `OPENSEARCH_DOCKER_REPO` pattern where compose files construct image references from repo + version variables
- Replace temporary per-developer image overrides (`ashisagr32966/opensearch-sql-main`, `joshuali925/opensearch-dashboards`) with official `opensearchstaging/opensearch:3.7.0` and `opensearchstaging/opensearch-dashboards:3.7.0`
- Updated across `.env`, `docker-compose.local-opensearch.yml`, `docker-compose.local-opensearch-dashboards.yml`, Helm `values.yaml`, and `install.sh`

## Test plan
- [x] `docker compose config` validates successfully
- [x] `docker compose up` — OpenSearch 3.7.0 starts and reports healthy
- [x] `docker compose up` — OpenSearch Dashboards 3.7.0 starts and reports healthy
- [x] `helm lint` passes
- [x] `helm template` renders correct `opensearchstaging/*:3.7.0` images
- [x] `helm install` on kind cluster — OpenSearch pod running and responding with version 3.7.0