### PR TITLE
feat: real APIs, Bedrock LLM integration, and Travel Agent Control Panel

### DIFF
--- a/docker-compose.examples.yml
+++ b/docker-compose.examples.yml
@@ -27,12 +27,18 @@ services:
       # FastAPI server endpoint
       - "${WEATHER_AGENT_PORT}:8000"
     environment:
-      # Override OTLP endpoint to use docker network
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://${OTEL_COLLECTOR_HOST}:${OTEL_COLLECTOR_PORT_GRPC}
       - MCP_SERVER_URL=http://mcp-server:8003
+      - FAULT_PANEL_URL=http://fault-panel:8085
+      - AWS_REGION=${AWS_REGION:-us-west-2}
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
+      - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN:-}
+      - BEDROCK_MODEL_ID=${BEDROCK_MODEL_ID:-us.anthropic.claude-opus-4-8}
     depends_on:
       - otel-collector
       - example-mcp-server
+      - example-fault-panel
     networks:
       - observability-stack-network
     restart: unless-stopped
@@ -49,7 +55,7 @@ services:
       dockerfile: Dockerfile
     container_name: fault-panel
     ports:
-      - "${FAULT_PANEL_PORT:-8085}:8080"
+      - "${FAULT_PANEL_PORT:-8085}:8085"
     volumes:
       - fault-panel-data:/data
     networks:
@@ -71,7 +77,7 @@ services:
       - TRAVEL_PLANNER_URL=http://travel-planner:8000
       - WEATHER_AGENT_URL=http://weather-agent:8000
       - EVENTS_AGENT_URL=http://events-agent:8002
-      - FAULT_PANEL_URL=http://fault-panel:8080
+      - FAULT_PANEL_URL=http://fault-panel:8085
       - CANARY_INTERVAL=${CANARY_INTERVAL}
     depends_on:
       - example-travel-planner
@@ -100,6 +106,12 @@ services:
       - WEATHER_AGENT_URL=http://weather-agent:8000
       - EVENTS_AGENT_URL=http://events-agent:8002
       - MCP_SERVER_URL=http://mcp-server:8003
+      - FAULT_PANEL_URL=http://fault-panel:8085
+      - AWS_REGION=${AWS_REGION:-us-west-2}
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
+      - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN:-}
+      - BEDROCK_MODEL_ID=${BEDROCK_MODEL_ID:-us.anthropic.claude-opus-4-8}
     depends_on:
       - otel-collector
       - example-weather-agent
@@ -146,9 +158,16 @@ services:
     environment:
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://${OTEL_COLLECTOR_HOST}:${OTEL_COLLECTOR_PORT_GRPC}
       - MCP_SERVER_URL=http://mcp-server:8003
+      - FAULT_PANEL_URL=http://fault-panel:8085
+      - AWS_REGION=${AWS_REGION:-us-west-2}
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
+      - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN:-}
+      - BEDROCK_MODEL_ID=${BEDROCK_MODEL_ID:-us.anthropic.claude-opus-4-8}
     depends_on:
       - otel-collector
       - example-mcp-server
+      - example-fault-panel
     networks:
       - observability-stack-network
     restart: unless-stopped

--- a/docker-compose.examples.yml
+++ b/docker-compose.examples.yml
@@ -34,7 +34,7 @@ services:
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
       - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN:-}
-      - BEDROCK_MODEL_ID=${BEDROCK_MODEL_ID:-us.anthropic.claude-opus-4-8}
+      - BEDROCK_MODEL_ID=${BEDROCK_MODEL_ID:-global.anthropic.claude-haiku-4-5-20251001-v1:0}
     depends_on:
       - otel-collector
       - example-mcp-server
@@ -111,7 +111,7 @@ services:
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
       - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN:-}
-      - BEDROCK_MODEL_ID=${BEDROCK_MODEL_ID:-us.anthropic.claude-opus-4-8}
+      - BEDROCK_MODEL_ID=${BEDROCK_MODEL_ID:-global.anthropic.claude-haiku-4-5-20251001-v1:0}
     depends_on:
       - otel-collector
       - example-weather-agent
@@ -163,7 +163,7 @@ services:
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
       - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN:-}
-      - BEDROCK_MODEL_ID=${BEDROCK_MODEL_ID:-us.anthropic.claude-opus-4-8}
+      - BEDROCK_MODEL_ID=${BEDROCK_MODEL_ID:-global.anthropic.claude-haiku-4-5-20251001-v1:0}
     depends_on:
       - otel-collector
       - example-mcp-server

--- a/docker-compose.examples.yml
+++ b/docker-compose.examples.yml
@@ -42,6 +42,25 @@ services:
           memory: ${WEATHER_AGENT_MEMORY_LIMIT}
     logging: *logging
 
+  # Travel Agent Control Panel - UI for toggling fault injection scenarios
+  example-fault-panel:
+    build:
+      context: ./docker-compose/fault-panel
+      dockerfile: Dockerfile
+    container_name: fault-panel
+    ports:
+      - "${FAULT_PANEL_PORT:-8085}:8080"
+    volumes:
+      - fault-panel-data:/data
+    networks:
+      - observability-stack-network
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 64M
+    logging: *logging
+
   # Canary Service - Periodically invokes travel-planner for testing
   example-canary:
     build:
@@ -52,11 +71,13 @@ services:
       - TRAVEL_PLANNER_URL=http://travel-planner:8000
       - WEATHER_AGENT_URL=http://weather-agent:8000
       - EVENTS_AGENT_URL=http://events-agent:8002
+      - FAULT_PANEL_URL=http://fault-panel:8080
       - CANARY_INTERVAL=${CANARY_INTERVAL}
     depends_on:
       - example-travel-planner
       - example-weather-agent
       - example-events-agent
+      - example-fault-panel
     networks:
       - observability-stack-network
     restart: unless-stopped
@@ -161,3 +182,6 @@ services:
         limits:
           memory: ${CANARY_MEMORY_LIMIT}
     logging: *logging
+
+volumes:
+  fault-panel-data:

--- a/docker-compose/canary/canary.py
+++ b/docker-compose/canary/canary.py
@@ -22,7 +22,7 @@ from datetime import datetime
 TRAVEL_PLANNER_URL = os.getenv("TRAVEL_PLANNER_URL", "http://travel-planner:8000")
 WEATHER_AGENT_URL = os.getenv("WEATHER_AGENT_URL", "http://weather-agent:8000")
 EVENTS_AGENT_URL = os.getenv("EVENTS_AGENT_URL", "http://events-agent:8002")
-FAULT_PANEL_URL = os.getenv("FAULT_PANEL_URL", "http://fault-panel:8080")
+FAULT_PANEL_URL = os.getenv("FAULT_PANEL_URL", "http://fault-panel:8085")
 CANARY_INTERVAL = int(os.getenv("CANARY_INTERVAL", "30"))
 
 DESTINATIONS = ["Paris", "Tokyo", "London", "Berlin", "Sydney", "New York", "Mumbai", "Seattle"]

--- a/docker-compose/canary/canary.py
+++ b/docker-compose/canary/canary.py
@@ -2,10 +2,13 @@
 """
 Canary Service - Periodic Travel Planner Invocation with Fault Injection
 
+Polls the Fault Control Panel for live configuration (fault weights, trace shapes,
+interval). Falls back to env-var defaults if the panel is unreachable.
+
 Generates traces with varying depths and shapes:
-- "normal": standard orchestrator call (37 spans, 4 services)
+- "normal": standard orchestrator call (40+ spans, 5 services, includes flights + currency)
 - "shallow": direct sub-agent call bypassing orchestrator (5-8 spans, 1-2 services)
-- "deep": multi-destination comparison via sequential orchestrator calls (70+ spans)
+- "deep": multi-destination comparison via sequential orchestrator calls (100+ spans)
 """
 
 import json
@@ -19,11 +22,13 @@ from datetime import datetime
 TRAVEL_PLANNER_URL = os.getenv("TRAVEL_PLANNER_URL", "http://travel-planner:8000")
 WEATHER_AGENT_URL = os.getenv("WEATHER_AGENT_URL", "http://weather-agent:8000")
 EVENTS_AGENT_URL = os.getenv("EVENTS_AGENT_URL", "http://events-agent:8002")
+FAULT_PANEL_URL = os.getenv("FAULT_PANEL_URL", "http://fault-panel:8080")
 CANARY_INTERVAL = int(os.getenv("CANARY_INTERVAL", "30"))
 
 DESTINATIONS = ["Paris", "Tokyo", "London", "Berlin", "Sydney", "New York", "Mumbai", "Seattle"]
+ORIGINS = ["Portland", "Seattle", "San Francisco", "New York", "Chicago", "Denver", "Austin", "Boston"]
 
-# Fault weights (applied to normal traces only)
+# Defaults (used when fault panel is unreachable)
 DEFAULT_FAULT_WEIGHTS = {
     "none": 0.50,
     "weather_error": 0.10,
@@ -33,15 +38,12 @@ DEFAULT_FAULT_WEIGHTS = {
     "events_rate_limited": 0.07,
     "partial_failure": 0.10,
 }
-FAULT_WEIGHTS = json.loads(os.getenv("FAULT_WEIGHTS", json.dumps(DEFAULT_FAULT_WEIGHTS)))
 
-# Trace shape weights control the mix of shallow / normal / deep traces
 DEFAULT_TRACE_SHAPE_WEIGHTS = {
     "normal": 0.60,
     "shallow": 0.25,
     "deep": 0.15,
 }
-TRACE_SHAPE_WEIGHTS = json.loads(os.getenv("TRACE_SHAPE_WEIGHTS", json.dumps(DEFAULT_TRACE_SHAPE_WEIGHTS)))
 
 FAULT_CONFIGS = {
     "none": None,
@@ -60,8 +62,37 @@ def weighted_choice(weights_dict):
     return random.choices(keys, weights=weights, k=1)[0]
 
 
-def select_fault():
-    selected = weighted_choice(FAULT_WEIGHTS)
+def fetch_config():
+    """Poll fault panel for current config. Returns None if unreachable."""
+    try:
+        resp = requests.get(f"{FAULT_PANEL_URL}/config", timeout=2)
+        if resp.status_code == 200:
+            return resp.json()
+    except Exception:
+        pass
+    return None
+
+
+def get_config():
+    """Get active config from panel or fall back to defaults."""
+    panel_config = fetch_config()
+    if panel_config:
+        return {
+            "enabled": panel_config.get("enabled", True),
+            "fault_weights": panel_config.get("fault_weights", DEFAULT_FAULT_WEIGHTS),
+            "trace_shape_weights": panel_config.get("trace_shape_weights", DEFAULT_TRACE_SHAPE_WEIGHTS),
+            "canary_interval": panel_config.get("canary_interval", CANARY_INTERVAL),
+        }
+    return {
+        "enabled": True,
+        "fault_weights": json.loads(os.getenv("FAULT_WEIGHTS", json.dumps(DEFAULT_FAULT_WEIGHTS))),
+        "trace_shape_weights": json.loads(os.getenv("TRACE_SHAPE_WEIGHTS", json.dumps(DEFAULT_TRACE_SHAPE_WEIGHTS))),
+        "canary_interval": CANARY_INTERVAL,
+    }
+
+
+def select_fault(fault_weights):
+    selected = weighted_choice(fault_weights)
     return selected, FAULT_CONFIGS.get(selected)
 
 
@@ -76,20 +107,29 @@ def check_health():
         return False
 
 
-def invoke_normal(destination):
-    """Standard orchestrator call — produces normal-depth traces."""
-    fault_name, fault_config = select_fault()
-    payload = {"destination": destination}
+def invoke_normal(destination, fault_weights):
+    """Standard orchestrator call — produces normal-depth traces with flights + currency."""
+    fault_name, fault_config = select_fault(fault_weights)
+    origin = random.choice(ORIGINS)
+    payload = {"destination": destination, "origin": origin}
     if fault_config:
         payload["fault"] = fault_config
 
-    print(f"  [normal] {destination} (fault: {fault_name})")
+    print(f"  [normal] {origin} → {destination} (fault: {fault_name})")
     response = requests.post(f"{TRAVEL_PLANNER_URL}/plan", json=payload, timeout=60)
     data = response.json()
 
     if response.status_code == 200:
         status = "partial" if data.get("partial") else "ok"
-        print(f"           → {status}")
+        has_flights = "flights" in data and data["flights"]
+        has_currency = "currency" in data and data["currency"]
+        extras = []
+        if has_flights:
+            extras.append("flights")
+        if has_currency:
+            extras.append("currency")
+        extra_str = f" +{','.join(extras)}" if extras else ""
+        print(f"           → {status}{extra_str}")
         return True
     print(f"           → error: {response.status_code}")
     return False
@@ -118,10 +158,11 @@ def invoke_shallow(destination):
 
 def invoke_deep(destinations):
     """Sequential multi-destination calls — produces deep traces."""
-    print(f"  [deep] comparing {len(destinations)} destinations: {', '.join(destinations)}")
+    origin = random.choice(ORIGINS)
+    print(f"  [deep] comparing {len(destinations)} destinations from {origin}: {', '.join(destinations)}")
     results = 0
     for dest in destinations:
-        payload = {"destination": dest}
+        payload = {"destination": dest, "origin": origin}
         try:
             response = requests.post(f"{TRAVEL_PLANNER_URL}/plan", json=payload, timeout=60)
             if response.status_code == 200:
@@ -136,8 +177,8 @@ def main():
     print("=" * 50)
     print("Canary - Travel Planner with Fault Injection")
     print(f"URL: {TRAVEL_PLANNER_URL}")
-    print(f"Interval: {CANARY_INTERVAL}s")
-    print(f"Trace shapes: {json.dumps(TRACE_SHAPE_WEIGHTS)}")
+    print(f"Fault Panel: {FAULT_PANEL_URL}")
+    print(f"Default Interval: {CANARY_INTERVAL}s")
     print("=" * 50)
 
     # Wait for service
@@ -154,9 +195,16 @@ def main():
 
     while True:
         try:
+            config = get_config()
+
+            if not config["enabled"]:
+                print(f"[{datetime.now().strftime('%H:%M:%S')}] paused (disabled via panel)")
+                time.sleep(config["canary_interval"])
+                continue
+
             count += 1
             timestamp = datetime.now().strftime("%H:%M:%S")
-            shape = weighted_choice(TRACE_SHAPE_WEIGHTS)
+            shape = weighted_choice(config["trace_shape_weights"])
             destination = random.choice(DESTINATIONS)
 
             print(f"[{timestamp}] invocation #{count}")
@@ -167,21 +215,20 @@ def main():
                 dests = random.sample(DESTINATIONS, k=random.randint(2, 4))
                 ok = invoke_deep(dests)
             else:
-                ok = invoke_normal(destination)
+                ok = invoke_normal(destination, config["fault_weights"])
 
             if ok:
                 success += 1
 
             print(f"         Success: {success}/{count} ({100*success/count:.0f}%)\n")
 
-            # Sleep after first invocation (not before) so data appears immediately on startup
-            time.sleep(CANARY_INTERVAL)
+            time.sleep(config["canary_interval"])
 
         except KeyboardInterrupt:
             break
         except Exception as e:
             print(f"Error: {e}")
-            time.sleep(CANARY_INTERVAL)
+            time.sleep(config.get("canary_interval", CANARY_INTERVAL))
 
 
 if __name__ == "__main__":

--- a/docker-compose/fault-panel/Dockerfile
+++ b/docker-compose/fault-panel/Dockerfile
@@ -5,5 +5,5 @@ COPY main.py .
 
 RUN pip install --no-cache-dir fastapi uvicorn
 
-EXPOSE 8080
+EXPOSE 8085
 CMD ["python", "main.py"]

--- a/docker-compose/fault-panel/Dockerfile
+++ b/docker-compose/fault-panel/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+COPY main.py .
+
+RUN pip install --no-cache-dir fastapi uvicorn
+
+EXPOSE 8080
+CMD ["python", "main.py"]

--- a/docker-compose/fault-panel/main.py
+++ b/docker-compose/fault-panel/main.py
@@ -1,0 +1,415 @@
+#!/usr/bin/env python3
+"""
+Travel Agent Control Panel — lightweight UI for toggling fault injection scenarios.
+The canary polls GET /config every cycle to pick up changes in real time.
+"""
+
+import json
+import os
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.responses import HTMLResponse
+from pydantic import BaseModel
+from typing import Optional
+
+
+app = FastAPI(title="Travel Agent Control Panel", version="1.0.0")
+
+STATE_FILE = Path(os.getenv("STATE_FILE", "/data/state.json"))
+
+DEFAULT_STATE = {
+    "enabled": True,
+    "fault_weights": {
+        "none": 0.50,
+        "weather_error": 0.10,
+        "weather_rate_limited": 0.08,
+        "weather_high_latency": 0.07,
+        "events_error": 0.08,
+        "events_rate_limited": 0.07,
+        "partial_failure": 0.10,
+    },
+    "trace_shape_weights": {
+        "normal": 0.60,
+        "shallow": 0.25,
+        "deep": 0.15,
+    },
+    "canary_interval": 30,
+    "preset": "default",
+}
+
+
+def load_state() -> dict:
+    if STATE_FILE.exists():
+        try:
+            return json.loads(STATE_FILE.read_text())
+        except (json.JSONDecodeError, OSError):
+            pass
+    return DEFAULT_STATE.copy()
+
+
+def save_state():
+    STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    STATE_FILE.write_text(json.dumps(state, indent=2))
+
+
+state = load_state()
+
+PRESETS = {
+    "default": {
+        "fault_weights": {
+            "none": 0.50,
+            "weather_error": 0.10,
+            "weather_rate_limited": 0.08,
+            "weather_high_latency": 0.07,
+            "events_error": 0.08,
+            "events_rate_limited": 0.07,
+            "partial_failure": 0.10,
+        },
+        "trace_shape_weights": {"normal": 0.60, "shallow": 0.25, "deep": 0.15},
+        "canary_interval": 30,
+    },
+    "all_clean": {
+        "fault_weights": {"none": 1.0},
+        "trace_shape_weights": {"normal": 0.60, "shallow": 0.25, "deep": 0.15},
+        "canary_interval": 30,
+    },
+    "chaos": {
+        "fault_weights": {
+            "none": 0.0,
+            "weather_error": 0.20,
+            "weather_rate_limited": 0.15,
+            "weather_high_latency": 0.15,
+            "events_error": 0.20,
+            "events_rate_limited": 0.15,
+            "partial_failure": 0.15,
+        },
+        "trace_shape_weights": {"normal": 0.50, "shallow": 0.20, "deep": 0.30},
+        "canary_interval": 10,
+    },
+    "latency_spike": {
+        "fault_weights": {
+            "none": 0.30,
+            "weather_high_latency": 0.70,
+        },
+        "trace_shape_weights": {"normal": 0.80, "shallow": 0.10, "deep": 0.10},
+        "canary_interval": 15,
+    },
+    "cascading_failure": {
+        "fault_weights": {
+            "none": 0.0,
+            "weather_error": 0.30,
+            "events_error": 0.30,
+            "partial_failure": 0.40,
+        },
+        "trace_shape_weights": {"normal": 0.70, "shallow": 0.0, "deep": 0.30},
+        "canary_interval": 10,
+    },
+    "deep_traces_only": {
+        "fault_weights": {"none": 1.0},
+        "trace_shape_weights": {"normal": 0.0, "shallow": 0.0, "deep": 1.0},
+        "canary_interval": 60,
+    },
+}
+
+
+class ConfigUpdate(BaseModel):
+    preset: Optional[str] = None
+    enabled: Optional[bool] = None
+    fault_weights: Optional[dict] = None
+    trace_shape_weights: Optional[dict] = None
+    canary_interval: Optional[int] = None
+
+
+@app.get("/health")
+async def health():
+    return {"status": "healthy"}
+
+
+@app.get("/config")
+async def get_config():
+    """Canary polls this endpoint every cycle."""
+    return state
+
+
+@app.post("/config")
+async def update_config(update: ConfigUpdate):
+    """UI posts changes here."""
+    if update.preset and update.preset in PRESETS:
+        preset = PRESETS[update.preset]
+        state["fault_weights"] = preset["fault_weights"]
+        state["trace_shape_weights"] = preset["trace_shape_weights"]
+        state["canary_interval"] = preset["canary_interval"]
+        state["preset"] = update.preset
+    if update.enabled is not None:
+        state["enabled"] = update.enabled
+    if update.fault_weights is not None:
+        state["fault_weights"] = update.fault_weights
+        state["preset"] = "custom"
+    if update.trace_shape_weights is not None:
+        state["trace_shape_weights"] = update.trace_shape_weights
+        state["preset"] = "custom"
+    if update.canary_interval is not None:
+        state["canary_interval"] = update.canary_interval
+    save_state()
+    return state
+
+
+@app.get("/presets")
+async def get_presets():
+    return PRESETS
+
+
+@app.get("/", response_class=HTMLResponse)
+async def ui():
+    return HTML_PAGE
+
+
+HTML_PAGE = """<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Travel Agent Control Panel</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #1a1a2e; color: #e0e0e0; padding: 32px 40px; min-height: 100vh; }
+  header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 28px; }
+  header .left h1 { font-size: 1.6rem; color: #fff; margin-bottom: 4px; }
+  header .left .subtitle { color: #888; font-size: 0.85rem; }
+  header .right { display: flex; align-items: center; gap: 20px; }
+  .switch { position: relative; width: 48px; height: 26px; flex-shrink: 0; }
+  .switch input { opacity: 0; width: 0; height: 0; }
+  .slider { position: absolute; cursor: pointer; inset: 0; background: #333; border-radius: 26px; transition: 0.3s; }
+  .slider:before { content: ""; position: absolute; height: 20px; width: 20px; left: 3px; bottom: 3px; background: #fff; border-radius: 50%; transition: 0.3s; }
+  .switch input:checked + .slider { background: #4cc9f0; }
+  .switch input:checked + .slider:before { transform: translateX(22px); }
+  .interval-group { display: flex; align-items: center; gap: 8px; }
+  .interval-group label { font-size: 0.85rem; color: #aaa; }
+  .interval-group input { width: 60px; background: #1a1a2e; border: 1px solid #0f3460; color: #e0e0e0; border-radius: 6px; padding: 5px 8px; text-align: center; font-size: 0.85rem; }
+
+  .grid { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; }
+  @media (max-width: 900px) { .grid { grid-template-columns: 1fr; } }
+
+  .card { background: #16213e; border-radius: 12px; padding: 24px; border: 1px solid #0f3460; }
+  .card h2 { font-size: 0.95rem; margin-bottom: 16px; color: #4cc9f0; }
+
+  .presets { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
+  .preset-btn { padding: 12px 16px; border-radius: 10px; border: 1px solid #0f3460; background: #1a1a2e; color: #e0e0e0; cursor: pointer; font-size: 0.85rem; transition: all 0.2s; text-align: left; }
+  .preset-btn:hover { border-color: #4cc9f0; color: #4cc9f0; }
+  .preset-btn.active { background: #4cc9f0; color: #1a1a2e; border-color: #4cc9f0; font-weight: 600; }
+  .preset-btn.custom { border-color: #f72585; }
+  .preset-btn.custom.active { background: #f72585; border-color: #f72585; color: #fff; }
+  .preset-btn .btn-label { display: block; font-weight: 600; margin-bottom: 3px; }
+  .preset-btn .btn-desc { display: block; font-size: 0.75rem; opacity: 0.7; font-weight: 400; }
+  .preset-btn .btn-look { display: block; font-size: 0.7rem; opacity: 0.5; margin-top: 4px; font-style: italic; }
+  .preset-btn.active .btn-desc { opacity: 0.9; }
+  .preset-btn.active .btn-look { opacity: 0.8; }
+
+  .bars-section { margin-bottom: 20px; }
+  .bars-section:last-child { margin-bottom: 0; }
+  .bars-section h3 { font-size: 0.8rem; color: #666; margin-bottom: 10px; text-transform: uppercase; letter-spacing: 0.5px; }
+  .bar-row { display: flex; align-items: center; gap: 12px; margin-bottom: 10px; }
+  .bar-row label { font-size: 0.82rem; min-width: 130px; color: #aaa; }
+  .bar-track { flex: 1; height: 8px; background: #0f3460; border-radius: 4px; overflow: hidden; }
+  .bar-fill { height: 100%; border-radius: 4px; transition: width 0.3s ease; }
+  .bar-fill.fault { background: linear-gradient(90deg, #4cc9f0, #4895ef); }
+  .bar-fill.shape { background: linear-gradient(90deg, #f72585, #b5179e); }
+  .bar-row .val { font-size: 0.8rem; min-width: 40px; text-align: right; color: #666; }
+  .bar-row.editable label { color: #e0e0e0; }
+  .bar-row.editable .val { color: #4cc9f0; }
+  input[type=range] { flex: 1; accent-color: #4cc9f0; height: 8px; }
+  input[type=range].shape-slider { accent-color: #f72585; }
+  .custom-note { font-size: 0.8rem; color: #f72585; margin-bottom: 14px; }
+
+  .status { margin-top: 20px; padding: 12px 16px; border-radius: 8px; background: #0f3460; font-size: 0.82rem; font-family: 'SF Mono', 'Fira Code', monospace; }
+  .status.ok { border-left: 4px solid #4cc9f0; }
+  .status.off { border-left: 4px solid #e63946; }
+</style>
+</head>
+<body>
+
+<header>
+  <div class="left">
+    <h1>Travel Agent Control Panel</h1>
+    <div class="subtitle">Toggle fault injection scenarios for the Travel Planner agents</div>
+  </div>
+  <div class="right">
+    <div class="interval-group">
+      <label>Interval:</label>
+      <input type="number" id="interval" value="30" min="5" max="300" onchange="updateInterval()">
+      <label>sec</label>
+    </div>
+    <label class="switch"><input type="checkbox" id="enabled" checked onchange="toggleEnabled()"><span class="slider"></span></label>
+  </div>
+</header>
+
+<div class="grid">
+  <div class="card">
+    <h2>Scenario</h2>
+    <div class="presets" id="presets"></div>
+  </div>
+
+  <div class="card" id="details-card">
+    <h2>Configuration</h2>
+    <div id="custom-note"></div>
+    <div class="bars-section">
+      <h3>Fault Injection</h3>
+      <div id="faults"></div>
+    </div>
+    <div class="bars-section">
+      <h3>Trace Shape</h3>
+      <div id="shapes"></div>
+    </div>
+  </div>
+</div>
+
+<div class="status ok" id="status">Loading...</div>
+
+<script>
+const FAULT_LABELS = {
+  none: 'No fault',
+  weather_error: 'Weather error',
+  weather_rate_limited: 'Weather rate limit',
+  weather_high_latency: 'Weather latency',
+  events_error: 'Events error',
+  events_rate_limited: 'Events rate limit',
+  partial_failure: 'Partial failure',
+};
+const SHAPE_LABELS = { normal: 'Normal', shallow: 'Shallow', deep: 'Deep' };
+const PRESET_META = {
+  all_clean:          { label: 'All Clean',          desc: 'Only healthy traces for baseline', look: 'All traces green, no errors in service map' },
+  default:            { label: 'Default',            desc: '50/50 mix of healthy and faults', look: 'Mix of green and red traces, partial failures visible' },
+  latency_spike:      { label: 'Latency Spike',     desc: '70% slow weather (5s delay)', look: 'P95 latency spike on weather-agent, long spans in waterfall' },
+  chaos:              { label: 'Chaos',              desc: 'Every request gets a random fault', look: 'High error rate across all services, red edges in service map' },
+  cascading_failure:  { label: 'Cascading Failure',  desc: 'Both sub-agents fail', look: 'Orchestrator shows partial=true, multiple error spans per trace' },
+  deep_traces_only:   { label: 'Deep Traces',       desc: '100+ span trace waterfalls', look: 'Very deep trace trees, 4+ sequential orchestrator calls' },
+  custom:             { label: 'Custom',             desc: 'Manually adjust weights below', look: 'Depends on your configuration' },
+};
+
+let config = {};
+let isCustom = false;
+
+async function load() {
+  const resp = await fetch('/config');
+  config = await resp.json();
+  isCustom = config.preset === 'custom';
+  render();
+}
+
+function render() {
+  document.getElementById('enabled').checked = config.enabled;
+  document.getElementById('interval').value = config.canary_interval;
+  isCustom = config.preset === 'custom';
+
+  const presetsEl = document.getElementById('presets');
+  presetsEl.innerHTML = Object.keys(PRESET_META).map(k => {
+    const cls = k === 'custom' ? 'preset-btn custom' : 'preset-btn';
+    const active = config.preset === k ? ' active' : '';
+    return `<button class="${cls}${active}" onclick="applyPreset('${k}')"><span class="btn-label">${PRESET_META[k].label}</span><span class="btn-desc">${PRESET_META[k].desc}</span><span class="btn-look">${PRESET_META[k].look}</span></button>`;
+  }).join('');
+
+  document.getElementById('custom-note').innerHTML = isCustom
+    ? '<p class="custom-note">Sliders are editable — drag to adjust weights</p>' : '';
+
+  const faultsEl = document.getElementById('faults');
+  faultsEl.innerHTML = Object.keys(FAULT_LABELS).map(k => {
+    const v = config.fault_weights[k] || 0;
+    const pct = Math.round(v * 100);
+    if (isCustom) {
+      return `<div class="bar-row editable">
+        <label>${FAULT_LABELS[k]}</label>
+        <input type="range" min="0" max="100" value="${pct}" oninput="setFault('${k}', this.value)">
+        <span class="val" id="fv_${k}">${pct}%</span>
+      </div>`;
+    }
+    return `<div class="bar-row">
+      <label>${FAULT_LABELS[k]}</label>
+      <div class="bar-track"><div class="bar-fill fault" style="width:${pct}%"></div></div>
+      <span class="val">${pct}%</span>
+    </div>`;
+  }).join('');
+
+  const shapesEl = document.getElementById('shapes');
+  shapesEl.innerHTML = Object.keys(SHAPE_LABELS).map(k => {
+    const v = config.trace_shape_weights[k] || 0;
+    const pct = Math.round(v * 100);
+    if (isCustom) {
+      return `<div class="bar-row editable">
+        <label>${SHAPE_LABELS[k]}</label>
+        <input type="range" class="shape-slider" min="0" max="100" value="${pct}" oninput="setShape('${k}', this.value)">
+        <span class="val" id="sv_${k}" style="color:#f72585">${pct}%</span>
+      </div>`;
+    }
+    return `<div class="bar-row">
+      <label>${SHAPE_LABELS[k]}</label>
+      <div class="bar-track"><div class="bar-fill shape" style="width:${pct}%"></div></div>
+      <span class="val">${pct}%</span>
+    </div>`;
+  }).join('');
+
+  updateStatus();
+}
+
+function updateStatus() {
+  const el = document.getElementById('status');
+  if (!config.enabled) {
+    el.className = 'status off';
+    el.textContent = 'PAUSED — canary is not sending traffic';
+  } else {
+    el.className = 'status ok';
+    const faults = Object.entries(config.fault_weights).filter(([k,v]) => k !== 'none' && v > 0);
+    const faultStr = faults.length ? faults.map(([k,v]) => `${k}:${Math.round(v*100)}%`).join('  ') : 'none';
+    el.textContent = `ACTIVE [${config.preset}]  interval=${config.canary_interval}s  faults: ${faultStr}`;
+  }
+}
+
+async function post(data) {
+  const resp = await fetch('/config', { method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify(data) });
+  config = await resp.json();
+  isCustom = config.preset === 'custom';
+  render();
+}
+
+function toggleEnabled() { post({ enabled: document.getElementById('enabled').checked }); }
+function updateInterval() { post({ canary_interval: parseInt(document.getElementById('interval').value) || 30 }); }
+function applyPreset(name) {
+  if (name === 'custom') {
+    isCustom = true;
+    config.preset = 'custom';
+    render();
+    return;
+  }
+  post({ preset: name });
+}
+
+function setFault(key, val) {
+  document.getElementById('fv_' + key).textContent = val + '%';
+  config.fault_weights[key] = parseInt(val) / 100;
+  debouncePost();
+}
+
+function setShape(key, val) {
+  document.getElementById('sv_' + key).textContent = val + '%';
+  config.trace_shape_weights[key] = parseInt(val) / 100;
+  debouncePost();
+}
+
+let timer = null;
+function debouncePost() {
+  clearTimeout(timer);
+  timer = setTimeout(() => {
+    post({ fault_weights: config.fault_weights, trace_shape_weights: config.trace_shape_weights });
+  }, 300);
+}
+
+load();
+</script>
+</body>
+</html>
+"""
+
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8080)

--- a/docker-compose/fault-panel/main.py
+++ b/docker-compose/fault-panel/main.py
@@ -20,6 +20,7 @@ STATE_FILE = Path(os.getenv("STATE_FILE", "/data/state.json"))
 
 DEFAULT_STATE = {
     "enabled": True,
+    "use_real_llm": False,
     "fault_weights": {
         "none": 0.50,
         "weather_error": 0.10,
@@ -40,12 +41,14 @@ DEFAULT_STATE = {
 
 
 def load_state() -> dict:
+    loaded = DEFAULT_STATE.copy()
     if STATE_FILE.exists():
         try:
-            return json.loads(STATE_FILE.read_text())
+            saved = json.loads(STATE_FILE.read_text())
+            loaded.update(saved)
         except (json.JSONDecodeError, OSError):
             pass
-    return DEFAULT_STATE.copy()
+    return loaded
 
 
 def save_state():
@@ -116,6 +119,7 @@ PRESETS = {
 class ConfigUpdate(BaseModel):
     preset: Optional[str] = None
     enabled: Optional[bool] = None
+    use_real_llm: Optional[bool] = None
     fault_weights: Optional[dict] = None
     trace_shape_weights: Optional[dict] = None
     canary_interval: Optional[int] = None
@@ -143,6 +147,8 @@ async def update_config(update: ConfigUpdate):
         state["preset"] = update.preset
     if update.enabled is not None:
         state["enabled"] = update.enabled
+    if update.use_real_llm is not None:
+        state["use_real_llm"] = update.use_real_llm
     if update.fault_weights is not None:
         state["fault_weights"] = update.fault_weights
         state["preset"] = "custom"
@@ -240,6 +246,10 @@ HTML_PAGE = """<!DOCTYPE html>
       <input type="number" id="interval" value="30" min="5" max="300" onchange="updateInterval()">
       <label>sec</label>
     </div>
+    <div class="interval-group">
+      <label>Real LLM</label>
+      <label class="switch"><input type="checkbox" id="use-real-llm" onchange="toggleRealLLM()"><span class="slider"></span></label>
+    </div>
     <label class="switch"><input type="checkbox" id="enabled" checked onchange="toggleEnabled()"><span class="slider"></span></label>
   </div>
 </header>
@@ -299,6 +309,7 @@ async function load() {
 
 function render() {
   document.getElementById('enabled').checked = config.enabled;
+  document.getElementById('use-real-llm').checked = config.use_real_llm || false;
   document.getElementById('interval').value = config.canary_interval;
   isCustom = config.preset === 'custom';
 
@@ -360,7 +371,8 @@ function updateStatus() {
     el.className = 'status ok';
     const faults = Object.entries(config.fault_weights).filter(([k,v]) => k !== 'none' && v > 0);
     const faultStr = faults.length ? faults.map(([k,v]) => `${k}:${Math.round(v*100)}%`).join('  ') : 'none';
-    el.textContent = `ACTIVE [${config.preset}]  interval=${config.canary_interval}s  faults: ${faultStr}`;
+    const llmStr = config.use_real_llm ? 'bedrock' : 'mock';
+    el.textContent = `ACTIVE [${config.preset}]  interval=${config.canary_interval}s  llm: ${llmStr}  faults: ${faultStr}`;
   }
 }
 
@@ -372,6 +384,7 @@ async function post(data) {
 }
 
 function toggleEnabled() { post({ enabled: document.getElementById('enabled').checked }); }
+function toggleRealLLM() { post({ use_real_llm: document.getElementById('use-real-llm').checked }); }
 function updateInterval() { post({ canary_interval: parseInt(document.getElementById('interval').value) || 30 }); }
 function applyPreset(name) {
   if (name === 'custom') {
@@ -412,4 +425,4 @@ load();
 
 if __name__ == "__main__":
     import uvicorn
-    uvicorn.run(app, host="0.0.0.0", port=8080)
+    uvicorn.run(app, host="0.0.0.0", port=8085)

--- a/examples/plain-agents/multi-agent-planner/README.md
+++ b/examples/plain-agents/multi-agent-planner/README.md
@@ -1,58 +1,159 @@
 # Multi-Agent Travel Planner
 
-A multi-agent example demonstrating distributed agent orchestration with OpenTelemetry instrumentation, MCP (Model Context Protocol) tool calls, and fault injection.
+A multi-agent example demonstrating distributed agent orchestration with OpenTelemetry instrumentation, real free APIs, Amazon Bedrock LLM integration, and a live control panel for fault injection.
 
 ## Architecture
 
 ```
-                    ┌─────────────────┐
-     Canary ──────▶ │ travel-planner  │ :8003
-                    └────────┬────────┘
-                             │
-                        ┌────┴────┐  [fan-out]
-                        ▼         ▼
-                    ┌───────┐ ┌───────┐
-                    │weather│ │events │
-                    │ agent │ │ agent │
-                    └───┬───┘ └───┬───┘
-                      :8000     :8002
-                        │         │
-                        └────┬────┘  [MCP tools/call]
-                             ▼
-                       ┌──────────┐
-                       │mcp-server│
-                       └──────────┘
-                          :8004
+                         ┌──────────────────┐
+          Canary ──────▶ │  travel-planner  │ :8003
+                         └────────┬─────────┘
+                                  │
+                   ┌──────────────┼──────────────┐
+                   │              │              │
+              [fan-out]      [sequential]   [sequential]
+                   │              │              │
+            ┌──────┴──────┐      │              │
+            ▼             ▼      ▼              ▼
+       ┌─────────┐  ┌─────────┐ │              │
+       │ weather │  │ events  │ │              │
+       │  agent  │  │  agent  │ │              │
+       └────┬────┘  └────┬────┘ │              │
+          :8000         :8002   │              │
+            │             │     │              │
+            └──────┬──────┘     │              │
+                   ▼            ▼              ▼
+              ┌──────────────────────────────────┐
+              │           mcp-server             │
+              │  fetch_weather  fetch_events     │
+              │  fetch_flights  convert_currency │
+              └──────────────────────────────────┘
+                            :8004
+                              │
+                 ┌────────────┼────────────┐
+                 ▼            ▼            ▼
+           Open-Meteo    Wikipedia    Frankfurter
+           (weather)    (attractions)  (currency)
+
+
+       ┌───────────────────┐
+       │  Control Panel    │ :8085   ◄── Toggle faults, LLM mode, interval
+       └───────────────────┘
 ```
 
 ## Services
 
 | Service | Port | Description |
 |---------|------|-------------|
-| travel-planner | 8003 | Orchestrator - fans out to sub-agents, synthesizes response |
-| weather-agent | 8000 | Weather lookup via MCP + local tools (forecast) |
-| events-agent | 8002 | Local events lookup via MCP |
-| mcp-server | 8004 | MCP tool provider (fetch_weather_api, fetch_events_api) |
-| canary | - | Periodic test client with fault injection |
+| travel-planner | 8003 | Orchestrator — fans out to sub-agents, calls flights/currency directly via MCP |
+| weather-agent | 8000 | Weather lookup with full agentic tool_use loop |
+| events-agent | 8002 | Attractions/POI lookup via MCP (Wikipedia) |
+| mcp-server | 8004 | MCP tool provider — 4 tools backed by real APIs |
+| fault-panel | 8085 | Travel Agent Control Panel — live UI for toggling scenarios |
+| canary | - | Periodic test client with configurable fault injection |
 
-## Features
+## Real APIs (No Keys Required)
 
-- **Trace context propagation**: All 4 services share the same trace via W3C TraceContext headers
-- **MCP semantic conventions**: Sub-agents call MCP server with proper CLIENT/SERVER span pairs
-- **Local vs MCP tools**: Weather-agent uses both MCP tools and local tools (get_forecast)
-- **Fault injection**: Test error handling at orchestrator and sub-agent levels
-- **Graceful degradation**: Partial failures return available data with error details
-- **Service map**: Shows 4 connected services in OpenSearch Dashboards
+The MCP server uses real free APIs that require zero setup:
+
+| Tool | API | Data |
+|------|-----|------|
+| `fetch_weather_api` | [Open-Meteo](https://open-meteo.com/) | Real temperature, conditions, wind (geocoding → forecast) |
+| `fetch_events_api` | [Wikipedia](https://www.mediawiki.org/wiki/API:Main_page) | Real landmarks and points of interest |
+| `convert_currency` | [Frankfurter](https://www.frankfurter.app/) | Live ECB exchange rates |
+| `fetch_flights_api` | Simulated | Realistic mock data (no free flight API exists) |
+
+All real API calls have **graceful fallback** — if an API is unreachable (network issues, rate limits), the MCP server falls back to mock data and sets `tool.fallback=true` on the span.
+
+## Real LLM (Amazon Bedrock)
+
+The agents support real LLM calls via Amazon Bedrock Converse API, toggled live from the control panel.
+
+### How It Works
+
+| Agent | Mock Mode | Real LLM Mode |
+|-------|-----------|---------------|
+| travel-planner | `time.sleep()` + random tokens | Bedrock plans the trip, then summarizes gathered results |
+| weather-agent | Keyword heuristics select tools | Bedrock uses `tool_use` to select and call weather tools |
+| events-agent | No reasoning, always calls tool | Bedrock reasons about what attractions to look for |
+
+### Setup
+
+1. Configure AWS credentials with Bedrock access:
+   ```bash
+   # Option A: Export from a named profile
+   eval $(aws configure export-credentials --profile bedrock --format env)
+
+   # Option B: Set in .env file
+   AWS_ACCESS_KEY_ID=...
+   AWS_SECRET_ACCESS_KEY=...
+   AWS_SESSION_TOKEN=...
+   AWS_REGION=us-west-2
+   ```
+
+2. Start the stack:
+   ```bash
+   docker compose up -d
+   ```
+
+3. Toggle "Real LLM" in the control panel at http://localhost:8085
+
+### Model Configuration
+
+Default model: `us.anthropic.claude-opus-4-8` (Claude Opus 4.8 via Bedrock cross-region inference)
+
+Override via environment variable:
+```bash
+BEDROCK_MODEL_ID=us.anthropic.claude-sonnet-4-20250514  # cheaper alternative
+```
+
+### Fallback Behavior
+
+If Bedrock is unavailable (no credentials, throttled, wrong model):
+- Agents fall back to mock mode automatically
+- Span attribute `gen_ai.bedrock.fallback=true` is set
+- `gen_ai.bedrock.fallback.reason` explains why
+- No user-facing errors — the demo continues working
+
+## Travel Agent Control Panel
+
+A web UI at **http://localhost:8085** for controlling the demo in real time.
+
+### Presets
+
+| Preset | Faults | Interval | What to look for in dashboards |
+|--------|--------|----------|-------------------------------|
+| All Clean | None | 30s | All traces green, no errors in service map |
+| Default | 50% mixed | 30s | Mix of green and red traces, partial failures |
+| Latency Spike | 70% weather delay | 15s | P95 latency spike on weather-agent |
+| Chaos | 100% faults | 10s | High error rate, red edges in service map |
+| Cascading Failure | Both agents fail | 10s | Orchestrator partial=true, multiple error spans |
+| Deep Traces | No faults | 60s | 100+ span trace waterfalls |
+| Custom | Adjustable | Adjustable | Editable sliders for fine-tuning |
+
+### Controls
+
+- **Enable/Disable** — pause/resume canary traffic
+- **Real LLM** — toggle between mock and Bedrock (agents poll every 30s)
+- **Interval** — how often the canary fires
+- **Fault sliders** — (Custom mode) adjust individual fault probabilities
+
+### Persistence
+
+State persists across container restarts via a Docker volume (`fault-panel-data`). Only `docker compose down -v` resets to defaults.
 
 ## Running
 
 From repository root:
 
 ```bash
+# Start full stack (mock LLM mode, no AWS creds needed)
+docker compose up -d
+
+# With Bedrock support
+eval $(aws configure export-credentials --profile bedrock --format env)
 docker compose up -d
 ```
-
-The multi-agent planner starts automatically with the example services.
 
 ## API
 
@@ -61,16 +162,18 @@ The multi-agent planner starts automatically with the example services.
 ```bash
 curl -X POST http://localhost:8003/plan \
   -H "Content-Type: application/json" \
-  -d '{"destination": "Paris"}'
+  -d '{"destination": "Paris", "origin": "New York"}'
 ```
 
 Response:
 ```json
 {
   "destination": "Paris",
-  "weather": {"response": "The weather in Paris is sunny..."},
-  "events": [{"name": "Louvre Late Night", "type": "museum", "venue": "Louvre Museum"}],
-  "recommendation": "Great choice! Paris looks wonderful...",
+  "weather": {"response": "The weather in Paris is mainly clear with a temperature of 64.9°F."},
+  "events": [{"name": "Landmarks in Paris", "type": "attraction", "venue": "paris"}],
+  "flights": {"flights": [{"airline": "JetBlue", "price_usd": 151, "stops": 0}]},
+  "currency": {"converted": 85.91, "to_currency": "EUR", "source": "frankfurter"},
+  "recommendation": "Paris is calling! Enjoy clear skies and a comfortable 65°F...",
   "partial": false,
   "errors": []
 }
@@ -78,94 +181,121 @@ Response:
 
 ### Fault Injection
 
-Inject faults to test error handling:
-
 ```bash
-# Sub-agent fault (events-agent returns error)
+# Weather agent rate-limited
 curl -X POST http://localhost:8003/plan \
   -H "Content-Type: application/json" \
-  -d '{
-    "destination": "Paris",
-    "fault": {
-      "events": {"type": "error"}
-    }
-  }'
+  -d '{"destination": "Tokyo", "fault": {"weather": {"type": "rate_limited"}}}'
 
-# Orchestrator fault (random partial failure)
+# Both sub-agents fail
 curl -X POST http://localhost:8003/plan \
   -H "Content-Type: application/json" \
-  -d '{
-    "destination": "Paris",
-    "fault": {
-      "orchestrator": "partial_failure"
-    }
-  }'
+  -d '{"destination": "Berlin", "fault": {"weather": {"type": "tool_error"}, "events": {"type": "error"}}}'
+
+# Orchestrator fan-out timeout
+curl -X POST http://localhost:8003/plan \
+  -H "Content-Type: application/json" \
+  -d '{"destination": "Sydney", "fault": {"orchestrator": "fan_out_timeout"}}'
+
+# High latency (5s delay)
+curl -X POST http://localhost:8003/plan \
+  -H "Content-Type: application/json" \
+  -d '{"destination": "London", "fault": {"weather": {"type": "high_latency", "delay_ms": 5000}}}'
 ```
 
-#### Available Faults
+#### Available Fault Types
 
 **Sub-agent faults** (weather/events):
-- `error` - Returns an error response
-- `rate_limited` - Simulates rate limiting
-- `high_latency` - Adds delay (use `delay_ms` parameter)
-- `timeout` - Simulates timeout
+- `error` / `tool_error` — returns error response
+- `rate_limited` — simulates 429 rate limiting
+- `high_latency` — adds configurable delay (`delay_ms`)
+- `timeout` — 30s hang then timeout
+- `wrong_city` — returns data for wrong destination
+- `empty` — returns empty results
 
-**Orchestrator faults**:
-- `partial_failure` - Randomly skip one sub-agent call
+**Weather-agent specific:**
+- `hallucination` — skips tool, fabricates answer
+- `token_limit_exceeded` — truncates response
+- `wrong_tool` — calls wrong tool
+
+**Orchestrator faults:**
+- `partial_failure` — randomly skip sub-agent calls
+- `fan_out_timeout` — 1ms timeout on all HTTP calls
 
 ## Telemetry
 
 View in OpenSearch Dashboards (http://localhost:5601):
 
-- **Trace Analytics**: See full request flow across all 4 services
-- **Service Map**: Visualize service dependencies (travel-planner → weather/events → mcp-server)
+- **Traces**: See full request flow across all services
+- **Service Map**: travel-planner → weather/events agents → mcp-server
 - **Span attributes**:
-  - `destination` - Requested city
-  - `response.partial` - True if any sub-agent failed
-  - `response.errors_count` - Number of failed sub-agents
-  - `mcp.method.name` - MCP method (tools/call)
-  - `mcp.session.id` - MCP session identifier
-  - `gen_ai.tool.name` - Tool being executed
-
-## Canary
-
-The canary service automatically generates traffic with fault injection:
-
-- Cycles through destinations: Paris, Tokyo, London, Berlin, Sydney, New York, Mumbai, Seattle
-- Injects faults based on configured weights (50% normal, 50% various faults)
-- Logs success rate and fault types
-
-View canary logs:
-```bash
-docker compose logs -f canary
-```
+  - `gen_ai.agent.name` — agent name (Travel Planner, Weather Assistant, Events Agent)
+  - `gen_ai.provider.name` — `aws_bedrock` (real) or `openai`/`anthropic`/etc. (mock)
+  - `gen_ai.request.model` — model used (e.g. `us.anthropic.claude-opus-4-8`)
+  - `gen_ai.usage.input_tokens` / `gen_ai.usage.output_tokens` — real token counts
+  - `gen_ai.input.messages` / `gen_ai.output.messages` — tool I/O content
+  - `gen_ai.tool.name` — tool being executed
+  - `gen_ai.bedrock.fallback` — true if Bedrock failed and agent used mock
+  - `tool.fallback` — true if external API failed and MCP used mock data
+  - `response.partial` — true if any sub-agent failed
 
 ## Trace Structure
 
-A typical trace shows the following span hierarchy:
+A typical trace (Real LLM mode) shows:
 
 ```
-travel-planner | invoke_agent (1745ms)
-├── chat (113ms)                                    # Initial LLM "thinking"
-├── invoke_agent weather-agent (1223ms)             # Sub-agent call
-│   └── weather-agent | invoke_agent (1204ms)
-│       └── execute_tool get_current_weather (196ms)
-│           └── tools/call fetch_weather_api [CLIENT] (195ms)  # MCP call
-│               └── mcp-server | tools/call [SERVER] (131ms)
-│                   └── tool_call fetch_weather_api (131ms)
-├── invoke_agent events-agent (270ms)               # Sub-agent call
-│   └── events-agent | invoke_agent (244ms)
-│       ├── chat (129ms)
-│       └── tools/call fetch_events_api [CLIENT] (111ms)       # MCP call
-│           └── mcp-server | tools/call [SERVER] (84ms)
-│               └── tool_call fetch_events_api (84ms)
-└── chat (108ms)                                    # Final response generation
+travel-planner | POST /plan (3200ms)
+├── invoke_agent Travel Planner (3180ms)
+│   ├── chat planning (1200ms)                         # Bedrock: plan the trip
+│   ├── invoke_agent weather-agent (800ms)             # Fan-out
+│   │   └── weather-agent | invoke_agent (780ms)
+│   │       ├── chat (600ms)                           # Bedrock: tool_use selection
+│   │       └── execute_tool get_current_weather (150ms)
+│   │           └── tools/call fetch_weather_api [CLIENT]
+│   │               └── mcp-server | tools/call [SERVER]
+│   │                   ├── geocode (80ms)             # Open-Meteo geocoding
+│   │                   └── open-meteo forecast (90ms) # Real weather API
+│   ├── invoke_agent events-agent (900ms)              # Fan-out
+│   │   └── events-agent | invoke_agent (880ms)
+│   │       ├── chat events-reasoning (700ms)          # Bedrock: what to look for
+│   │       └── execute_tool fetch_events_api [CLIENT]
+│   │           └── mcp-server | tools/call [SERVER]
+│   │               └── wikipedia search (200ms)       # Real Wikipedia API
+│   ├── execute_tool fetch_flights_api (100ms)         # Direct MCP call
+│   │   └── mcp-server | tools/call [SERVER]
+│   │       └── tool_call fetch_flights_api (5ms)      # Simulated
+│   ├── execute_tool convert_currency (150ms)          # Direct MCP call
+│   │   └── mcp-server | tools/call [SERVER]
+│   │       └── frankfurter exchange (140ms)           # Real ECB rates
+│   └── chat summarize (1000ms)                        # Bedrock: synthesize recommendation
 ```
 
-**Span types:**
-- `invoke_agent` - Agent invocation (orchestrator → sub-agent)
-- `chat` - LLM call with token counts
-- `execute_tool` - Tool execution wrapper
-- `tools/call` - MCP protocol call (CLIENT/SERVER pair)
-- `tool_call` - Actual tool execution in MCP server
-- `local_tool` - Local tool execution (no MCP, e.g., get_forecast)
+## Canary
+
+The canary service generates continuous traffic:
+
+- **Destinations**: Paris, Tokyo, London, Berlin, Sydney, New York, Mumbai, Seattle
+- **Origins**: Portland, Seattle, San Francisco, New York, Chicago, Denver, Austin, Boston
+- **Trace shapes**: normal (60%), shallow (25%), deep (15%)
+- **Faults**: configurable via control panel
+
+```bash
+# View canary logs
+docker compose logs -f example-canary
+
+# Stop canary (useful when Real LLM is on to save costs)
+docker compose stop example-canary
+```
+
+## Cost Awareness
+
+With **Real LLM ON** and canary running at default 30s interval:
+- ~4-5 Bedrock calls per normal invocation
+- ~8-20 calls per deep invocation
+- Opus 4.8 pricing applies
+
+To minimize cost during demos:
+- Increase interval to 120s+ in the control panel
+- Use `BEDROCK_MODEL_ID=us.anthropic.claude-sonnet-4-20250514` (cheaper)
+- Pause canary and test manually
+- Toggle Real LLM OFF when not actively demoing

--- a/examples/plain-agents/multi-agent-planner/README.md
+++ b/examples/plain-agents/multi-agent-planner/README.md
@@ -100,11 +100,12 @@ The agents support real LLM calls via Amazon Bedrock Converse API, toggled live 
 
 ### Model Configuration
 
-Default model: `us.anthropic.claude-opus-4-8` (Claude Opus 4.8 via Bedrock cross-region inference)
+Default model: `global.anthropic.claude-haiku-4-5-20251001-v1:0` (Claude Haiku 4.5 — fast and cost-effective)
 
 Override via environment variable:
 ```bash
-BEDROCK_MODEL_ID=us.anthropic.claude-sonnet-4-20250514  # cheaper alternative
+BEDROCK_MODEL_ID=global.anthropic.claude-sonnet-4-6         # more capable
+BEDROCK_MODEL_ID=global.anthropic.claude-opus-4-8           # most capable, highest cost
 ```
 
 ### Fallback Behavior

--- a/examples/plain-agents/multi-agent-planner/events-agent/Dockerfile
+++ b/examples/plain-agents/multi-agent-planner/events-agent/Dockerfile
@@ -7,6 +7,8 @@ RUN pip install --no-cache-dir \
     fastapi \
     uvicorn \
     httpx \
+    requests \
+    boto3 \
     opensearch-genai-observability-sdk-py>=0.2.7 \
     opentelemetry-exporter-otlp-proto-grpc \
     opentelemetry-instrumentation-asgi

--- a/examples/plain-agents/multi-agent-planner/events-agent/bedrock_client.py
+++ b/examples/plain-agents/multi-agent-planner/events-agent/bedrock_client.py
@@ -13,7 +13,7 @@ from botocore.exceptions import ClientError, NoCredentialsError, EndpointConnect
 
 logger = logging.getLogger(__name__)
 
-BEDROCK_MODEL_ID = os.getenv("BEDROCK_MODEL_ID", "us.anthropic.claude-opus-4-8")
+BEDROCK_MODEL_ID = os.getenv("BEDROCK_MODEL_ID", "global.anthropic.claude-haiku-4-5-20251001-v1:0")
 BEDROCK_REGION = os.getenv("AWS_REGION", os.getenv("AWS_DEFAULT_REGION", "us-west-2"))
 
 

--- a/examples/plain-agents/multi-agent-planner/events-agent/bedrock_client.py
+++ b/examples/plain-agents/multi-agent-planner/events-agent/bedrock_client.py
@@ -1,0 +1,121 @@
+"""
+Amazon Bedrock Converse API client for real LLM calls.
+Uses boto3 with the default credential chain (env vars, ~/.aws/credentials, instance role).
+"""
+
+import json
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+import boto3
+from botocore.exceptions import ClientError, NoCredentialsError, EndpointConnectionError
+
+logger = logging.getLogger(__name__)
+
+BEDROCK_MODEL_ID = os.getenv("BEDROCK_MODEL_ID", "us.anthropic.claude-opus-4-8")
+BEDROCK_REGION = os.getenv("AWS_REGION", os.getenv("AWS_DEFAULT_REGION", "us-west-2"))
+
+
+class BedrockUnavailableError(Exception):
+    pass
+
+
+def get_bedrock_client():
+    """Create Bedrock Runtime client. Returns None if credentials are missing."""
+    try:
+        client = boto3.client("bedrock-runtime", region_name=BEDROCK_REGION)
+        return client
+    except (NoCredentialsError, Exception) as e:
+        logger.warning(f"Bedrock client init failed: {e}")
+        return None
+
+
+def openai_tools_to_bedrock(tools: List[Dict]) -> Dict:
+    """Convert OpenAI-style tool definitions to Bedrock toolConfig format."""
+    bedrock_tools = []
+    for tool in tools:
+        func = tool.get("function", tool)
+        bedrock_tools.append({
+            "toolSpec": {
+                "name": func["name"],
+                "description": func.get("description", ""),
+                "inputSchema": {
+                    "json": func.get("parameters", {"type": "object", "properties": {}})
+                }
+            }
+        })
+    return {"tools": bedrock_tools}
+
+
+def converse(
+    client,
+    messages: List[Dict[str, Any]],
+    system: Optional[str] = None,
+    tool_config: Optional[Dict] = None,
+    model_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """
+    Call Bedrock Converse API.
+
+    Args:
+        client: boto3 bedrock-runtime client
+        messages: Bedrock message format [{"role": "user", "content": [{"text": "..."}]}]
+        system: Optional system prompt
+        tool_config: Optional Bedrock toolConfig dict
+        model_id: Model to use (defaults to BEDROCK_MODEL_ID)
+
+    Returns:
+        Full Converse API response dict with output, usage, stopReason
+
+    Raises:
+        BedrockUnavailableError on credential/throttle/connection issues
+    """
+    kwargs = {
+        "modelId": model_id or BEDROCK_MODEL_ID,
+        "messages": messages,
+    }
+    if system:
+        kwargs["system"] = [{"text": system}]
+    if tool_config:
+        kwargs["toolConfig"] = tool_config
+
+    try:
+        response = client.converse(**kwargs)
+        return response
+    except NoCredentialsError as e:
+        raise BedrockUnavailableError(f"No AWS credentials: {e}")
+    except EndpointConnectionError as e:
+        raise BedrockUnavailableError(f"Cannot reach Bedrock endpoint: {e}")
+    except ClientError as e:
+        error_code = e.response["Error"]["Code"]
+        if error_code in ("ThrottlingException", "ServiceUnavailableException", "AccessDeniedException", "ValidationException"):
+            raise BedrockUnavailableError(f"Bedrock error: {error_code} - {e.response['Error']['Message']}")
+        raise
+
+
+def extract_text(response: Dict) -> str:
+    """Extract text content from a Converse API response."""
+    message = response.get("output", {}).get("message", {})
+    for block in message.get("content", []):
+        if "text" in block:
+            return block["text"]
+    return ""
+
+
+def extract_tool_use(response: Dict) -> Optional[Dict]:
+    """Extract the first toolUse block from a Converse API response."""
+    message = response.get("output", {}).get("message", {})
+    for block in message.get("content", []):
+        if "toolUse" in block:
+            return block["toolUse"]
+    return None
+
+
+def get_usage(response: Dict) -> Dict[str, int]:
+    """Extract token usage from response."""
+    usage = response.get("usage", {})
+    return {
+        "input_tokens": usage.get("inputTokens", 0),
+        "output_tokens": usage.get("outputTokens", 0),
+    }

--- a/examples/plain-agents/multi-agent-planner/events-agent/main.py
+++ b/examples/plain-agents/multi-agent-planner/events-agent/main.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
-Events Agent - Fetches local events for a destination.
-Supports fault injection for testing observability.
+Events Agent - Fetches attractions and points of interest for a destination.
+Uses Wikipedia via MCP server for real data. Supports fault injection for testing observability.
 
 Instrumented with opensearch-genai-observability-sdk-py:
 - register() replaces ~20 lines of manual TracerProvider/exporter setup
@@ -45,7 +45,7 @@ TOOL_DEFINITIONS = [
         "type": "function",
         "function": {
             "name": "fetch_events_api",
-            "description": "Fetch local events from the events database for a destination",
+            "description": "Fetch attractions and points of interest from Wikipedia for a destination",
             "parameters": {"type": "object", "properties": {"destination": {"type": "string"}, "date": {"type": "string"}}, "required": ["destination"]}
         }
     }
@@ -284,7 +284,7 @@ async def get_events(request: EventsRequest):
             resp = httpx.post(f"{MCP_SERVER_URL}/mcp", json=payload, headers=headers, timeout=30)
             mcp_result = resp.json().get("result", {})
             events_list = mcp_result.get("events", [])
-            events = [Event(name=e["name"], type=e["type"], venue=e.get("venue", "TBD"), date=e.get("date", date)) for e in events_list]
+            events = [Event(name=e["name"], type=e.get("type", "attraction"), venue=e.get("venue", destination.title()), date=e.get("date", date)) for e in events_list]
 
         span.set_attribute("events.count", len(events))
 

--- a/examples/plain-agents/multi-agent-planner/events-agent/main.py
+++ b/examples/plain-agents/multi-agent-planner/events-agent/main.py
@@ -11,12 +11,14 @@ Instrumented with opensearch-genai-observability-sdk-py:
 import json
 import os
 import random
+import threading
 import time
 from datetime import datetime
 from typing import Optional
 from uuid import uuid4
 
 import httpx
+import requests as req_lib
 from fastapi import FastAPI
 from opentelemetry import trace, metrics
 from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
@@ -29,11 +31,34 @@ from opentelemetry.propagate import inject
 from pydantic import BaseModel, Field
 
 from opensearch_genai_observability_sdk_py import Op, enrich, observe, register
+from bedrock_client import (
+    get_bedrock_client, converse, extract_text, get_usage,
+    BedrockUnavailableError, BEDROCK_MODEL_ID,
+)
 
 
 # MCP Server configuration
 MCP_SERVER_URL = os.getenv("MCP_SERVER_URL", "http://mcp-server:8003")
 MCP_PROTOCOL_VERSION = "2025-06-18"
+FAULT_PANEL_URL = os.getenv("FAULT_PANEL_URL", "http://fault-panel:8085")
+
+_config_cache = {"use_real_llm": False}
+
+
+def _poll_config():
+    while True:
+        try:
+            resp = req_lib.get(f"{FAULT_PANEL_URL}/config", timeout=2)
+            if resp.status_code == 200:
+                _config_cache["use_real_llm"] = resp.json().get("use_real_llm", False)
+        except Exception:
+            pass
+        time.sleep(30)
+
+
+threading.Thread(target=_poll_config, daemon=True).start()
+
+_bedrock_client = get_bedrock_client()
 
 
 AGENT_ID = "events-agent-001"
@@ -206,16 +231,33 @@ async def get_events(request: EventsRequest):
         date = request.date or datetime.now().strftime("%Y-%m-%d")
         fault = request.fault
 
-        # Synthetic "thinking" LLM call
-        with observe("events-reasoning", op=Op.CHAT):
-            enrich(
-                model=model,
-                provider=provider,
-                input_tokens=random.randint(100, 500),
-                output_tokens=random.randint(50, 200),
-                finish_reason="tool_calls",
-            )
-            time.sleep(random.uniform(0.05, 0.15))
+        # LLM reasoning call
+        with observe("events-reasoning", op=Op.CHAT) as reasoning_span:
+            if _config_cache["use_real_llm"] and _bedrock_client:
+                try:
+                    reasoning_messages = [{"role": "user", "content": [{"text": f"What are the top attractions and things to do in {request.destination}? List briefly."}]}]
+                    reasoning_response = converse(
+                        _bedrock_client, reasoning_messages,
+                        system="You are a travel events assistant. Briefly suggest what to look for.",
+                    )
+                    usage = get_usage(reasoning_response)
+                    enrich(
+                        model=BEDROCK_MODEL_ID,
+                        provider="aws_bedrock",
+                        input_tokens=usage["input_tokens"],
+                        output_tokens=usage["output_tokens"],
+                        finish_reason=reasoning_response.get("stopReason", "end_turn"),
+                        input_messages=[{"role": "user", "parts": [{"type": "text", "content": f"What to do in {request.destination}?"}]}],
+                        output_messages=[{"role": "assistant", "parts": [{"type": "text", "content": extract_text(reasoning_response)}]}],
+                    )
+                except BedrockUnavailableError as e:
+                    reasoning_span.set_attribute("gen_ai.bedrock.fallback", True)
+                    reasoning_span.set_attribute("gen_ai.bedrock.fallback.reason", str(e)[:200])
+                    enrich(model=model, provider=provider, input_tokens=random.randint(100, 500), output_tokens=random.randint(50, 200), finish_reason="tool_calls")
+                    time.sleep(random.uniform(0.05, 0.15))
+            else:
+                enrich(model=model, provider=provider, input_tokens=random.randint(100, 500), output_tokens=random.randint(50, 200), finish_reason="tool_calls")
+                time.sleep(random.uniform(0.05, 0.15))
 
         # Check for fault injection
         if should_inject_fault(fault):
@@ -275,6 +317,10 @@ async def get_events(request: EventsRequest):
             tool_span.set_attribute("network.transport", "tcp")
             tool_span.set_attribute("network.protocol.name", "http")
 
+            enrich(
+                input_messages=[{"role": "tool_call", "parts": [{"type": "text", "content": json.dumps({"destination": destination})}]}],
+            )
+
             headers = {"mcp-session-id": session_id}
             inject(headers)
             payload = {
@@ -285,6 +331,10 @@ async def get_events(request: EventsRequest):
             mcp_result = resp.json().get("result", {})
             events_list = mcp_result.get("events", [])
             events = [Event(name=e["name"], type=e.get("type", "attraction"), venue=e.get("venue", destination.title()), date=e.get("date", date)) for e in events_list]
+
+            enrich(
+                output_messages=[{"role": "tool_result", "parts": [{"type": "text", "content": json.dumps(mcp_result)}]}],
+            )
 
         span.set_attribute("events.count", len(events))
 

--- a/examples/plain-agents/multi-agent-planner/mcp-server/Dockerfile
+++ b/examples/plain-agents/multi-agent-planner/mcp-server/Dockerfile
@@ -6,6 +6,7 @@ COPY . .
 RUN pip install --no-cache-dir \
     fastapi \
     uvicorn \
+    httpx \
     opentelemetry-api \
     opentelemetry-sdk \
     opentelemetry-exporter-otlp-proto-grpc \

--- a/examples/plain-agents/multi-agent-planner/mcp-server/main.py
+++ b/examples/plain-agents/multi-agent-planner/mcp-server/main.py
@@ -2,6 +2,12 @@
 """
 MCP Server - Provides low-level tools via MCP protocol.
 Sub-agents call this server to execute actual tool logic.
+
+Uses real free APIs (no API keys required):
+- Open-Meteo for weather (geocoding + forecast)
+- Wikipedia for attractions/points of interest
+- Frankfurter for currency conversion
+- Mock data for flights (no free flight API exists)
 """
 
 import os
@@ -9,6 +15,7 @@ import random
 import time
 from uuid import uuid4
 
+import httpx
 from fastapi import FastAPI, Request
 from opentelemetry import trace
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
@@ -23,17 +30,55 @@ from typing import Optional
 
 MCP_PROTOCOL_VERSION = "2025-06-18"
 
-# Available tools - leaf-level APIs that sub-agents call
 TOOLS = {
     "fetch_weather_api": {
-        "description": "Fetch weather data from external weather API",
+        "description": "Fetch current weather from Open-Meteo API (real data)",
         "parameters": {"type": "object", "properties": {"location": {"type": "string"}}, "required": ["location"]}
     },
     "fetch_events_api": {
-        "description": "Fetch events data from external events API",
+        "description": "Fetch attractions and points of interest from Wikipedia (real data)",
         "parameters": {"type": "object", "properties": {"destination": {"type": "string"}}, "required": ["destination"]}
+    },
+    "fetch_flights_api": {
+        "description": "Search for flights between two cities (simulated realistic data)",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "origin": {"type": "string"},
+                "destination": {"type": "string"},
+                "date": {"type": "string", "description": "Travel date YYYY-MM-DD"}
+            },
+            "required": ["origin", "destination"]
+        }
+    },
+    "convert_currency": {
+        "description": "Convert amount between currencies using live ECB exchange rates via Frankfurter API",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "amount": {"type": "number"},
+                "from_currency": {"type": "string", "description": "ISO 4217 code e.g. USD"},
+                "to_currency": {"type": "string", "description": "ISO 4217 code e.g. EUR"}
+            },
+            "required": ["amount", "from_currency", "to_currency"]
+        }
     }
 }
+
+WMO_WEATHER_CODES = {
+    0: "clear sky", 1: "mainly clear", 2: "partly cloudy", 3: "overcast",
+    45: "foggy", 48: "depositing rime fog",
+    51: "light drizzle", 53: "moderate drizzle", 55: "dense drizzle",
+    61: "slight rain", 63: "moderate rain", 65: "heavy rain",
+    71: "slight snow", 73: "moderate snow", 75: "heavy snow",
+    80: "slight rain showers", 81: "moderate rain showers", 82: "violent rain showers",
+    85: "slight snow showers", 86: "heavy snow showers",
+    95: "thunderstorm", 96: "thunderstorm with slight hail", 99: "thunderstorm with heavy hail",
+}
+
+AIRLINES = ["United", "Delta", "Alaska", "Southwest", "JetBlue", "American", "Spirit", "Frontier"]
+
+_geocode_cache: dict[str, tuple[float, float, str]] = {}
 
 
 def setup_telemetry():
@@ -70,7 +115,6 @@ async def handle_mcp(request: Request, body: ToolCallRequest):
     tool_name = body.params.get("name", "unknown")
     arguments = body.params.get("arguments", {})
 
-    # MCP SERVER span (protocol layer)
     with tracer.start_as_current_span(
         f"tools/call {tool_name}",
         context=ctx,
@@ -86,7 +130,6 @@ async def handle_mcp(request: Request, body: ToolCallRequest):
             "network.protocol.name": "http",
         },
     ) as mcp_span:
-        # Tool execution span (application layer)
         with tracer.start_as_current_span(
             f"tool_call {tool_name}",
             kind=SpanKind.INTERNAL,
@@ -97,7 +140,7 @@ async def handle_mcp(request: Request, body: ToolCallRequest):
             },
         ) as tool_span:
             try:
-                result = execute_tool(tool_name, arguments)
+                result = await execute_tool(tool_name, arguments, tool_span)
                 return {"jsonrpc": "2.0", "id": request_id, "result": result}
             except Exception as e:
                 tool_span.set_status(Status(StatusCode.ERROR, str(e)))
@@ -105,30 +148,260 @@ async def handle_mcp(request: Request, body: ToolCallRequest):
                 return {"jsonrpc": "2.0", "id": request_id, "error": {"code": -32000, "message": str(e)}}
 
 
-def execute_tool(name: str, args: dict) -> dict:
-    """Execute tool and return result."""
-    time.sleep(random.uniform(0.05, 0.15))  # Simulate API latency
+async def geocode_city(city: str) -> tuple[float, float, str]:
+    """Resolve city name to lat/lon using Open-Meteo geocoding API."""
+    cache_key = city.lower().strip()
+    if cache_key in _geocode_cache:
+        return _geocode_cache[cache_key]
 
+    with tracer.start_as_current_span(
+        "geocode",
+        kind=SpanKind.CLIENT,
+        attributes={"geocode.query": city},
+    ) as span:
+        async with httpx.AsyncClient(timeout=5.0, follow_redirects=True) as client:
+            resp = await client.get(
+                "https://geocoding-api.open-meteo.com/v1/search",
+                params={"name": city, "count": 1, "language": "en", "format": "json"},
+            )
+            data = resp.json()
+            results = data.get("results", [])
+            if not results:
+                raise ValueError(f"Could not geocode city: {city}")
+            lat = results[0]["latitude"]
+            lon = results[0]["longitude"]
+            resolved_name = results[0].get("name", city)
+            span.set_attribute("geocode.lat", lat)
+            span.set_attribute("geocode.lon", lon)
+            span.set_attribute("geocode.resolved_name", resolved_name)
+            _geocode_cache[cache_key] = (lat, lon, resolved_name)
+            return lat, lon, resolved_name
+
+
+async def fetch_weather(location: str) -> dict:
+    """Fetch real weather from Open-Meteo API."""
+    lat, lon, resolved_name = await geocode_city(location)
+
+    with tracer.start_as_current_span(
+        "open-meteo forecast",
+        kind=SpanKind.CLIENT,
+        attributes={"http.url.path": "/v1/forecast", "weather.location": resolved_name},
+    ):
+        async with httpx.AsyncClient(timeout=5.0, follow_redirects=True) as client:
+            resp = await client.get(
+                "https://api.open-meteo.com/v1/forecast",
+                params={
+                    "latitude": lat,
+                    "longitude": lon,
+                    "current_weather": "true",
+                    "temperature_unit": "fahrenheit",
+                    "windspeed_unit": "mph",
+                },
+            )
+            data = resp.json()
+            current = data.get("current_weather", {})
+            weather_code = current.get("weathercode", 0)
+            condition = WMO_WEATHER_CODES.get(weather_code, "unknown")
+
+            return {
+                "location": resolved_name,
+                "temperature": f"{current.get('temperature', 'N/A')}°F",
+                "condition": condition,
+                "wind_speed": f"{current.get('windspeed', 'N/A')} mph",
+                "wind_direction": f"{current.get('winddirection', 'N/A')}°",
+                "source": "open-meteo",
+            }
+
+
+async def fetch_attractions(destination: str) -> dict:
+    """Fetch real attractions from Wikipedia API."""
+    with tracer.start_as_current_span(
+        "wikipedia search",
+        kind=SpanKind.CLIENT,
+        attributes={"wikipedia.query": destination},
+    ):
+        async with httpx.AsyncClient(timeout=5.0, follow_redirects=True) as client:
+            # Get city summary
+            resp = await client.get(
+                f"https://en.wikipedia.org/api/rest_v1/page/summary/{destination}",
+                headers={"User-Agent": "ObservabilityStackDemo/1.0"},
+            )
+            summary = ""
+            if resp.status_code == 200:
+                summary = resp.json().get("extract", "")
+
+            # Search for attractions
+            search_resp = await client.get(
+                "https://en.wikipedia.org/w/api.php",
+                params={
+                    "action": "query",
+                    "list": "search",
+                    "srsearch": f"{destination} tourist attractions landmarks",
+                    "srlimit": 5,
+                    "format": "json",
+                },
+                headers={"User-Agent": "ObservabilityStackDemo/1.0"},
+            )
+            events = []
+            if search_resp.status_code == 200:
+                search_data = search_resp.json()
+                results = search_data.get("query", {}).get("search", [])
+                for r in results:
+                    title = r.get("title", "")
+                    snippet = r.get("snippet", "").replace('<span class="searchmatch">', "").replace("</span>", "")
+                    events.append({
+                        "name": title,
+                        "type": "attraction",
+                        "venue": destination,
+                        "description": snippet[:150],
+                    })
+
+            return {
+                "destination": destination,
+                "summary": summary[:300] if summary else f"Explore {destination}",
+                "events": events if events else [{"name": f"{destination} City Tour", "type": "tour", "venue": destination}],
+                "source": "wikipedia",
+            }
+
+
+async def fetch_flights(origin: str, destination: str, date: str = None) -> dict:
+    """Generate realistic mock flight data (no free flight API exists)."""
+    num_flights = random.randint(2, 4)
+    flights = []
+    for i in range(num_flights):
+        dep_hour = random.randint(6, 20)
+        duration_min = random.randint(45, 320)
+        arr_hour = dep_hour + duration_min // 60
+        price = random.randint(89, 650)
+        flights.append({
+            "airline": random.choice(AIRLINES),
+            "departure": f"{dep_hour:02d}:{random.randint(0,59):02d}",
+            "arrival": f"{arr_hour % 24:02d}:{random.randint(0,59):02d}",
+            "duration_minutes": duration_min,
+            "price_usd": price,
+            "stops": random.choice([0, 0, 0, 1, 1, 2]),
+        })
+    flights.sort(key=lambda f: f["price_usd"])
+
+    return {
+        "origin": origin,
+        "destination": destination,
+        "date": date or "flexible",
+        "flights": flights,
+        "source": "simulated",
+    }
+
+
+async def convert_currency_api(amount: float, from_currency: str, to_currency: str) -> dict:
+    """Convert currency using Frankfurter API (real ECB exchange rates)."""
+    with tracer.start_as_current_span(
+        "frankfurter exchange",
+        kind=SpanKind.CLIENT,
+        attributes={
+            "currency.from": from_currency,
+            "currency.to": to_currency,
+            "currency.amount": amount,
+        },
+    ):
+        async with httpx.AsyncClient(timeout=5.0, follow_redirects=True) as client:
+            resp = await client.get(
+                "https://api.frankfurter.app/latest",
+                params={"from": from_currency.upper(), "to": to_currency.upper(), "amount": amount},
+            )
+            data = resp.json()
+            converted = data.get("rates", {}).get(to_currency.upper(), 0)
+            return {
+                "amount": amount,
+                "from_currency": from_currency.upper(),
+                "to_currency": to_currency.upper(),
+                "converted": converted,
+                "rate": converted / amount if amount else 0,
+                "date": data.get("date", "unknown"),
+                "source": "frankfurter",
+            }
+
+
+def _fallback_weather(location: str) -> dict:
+    """Fallback mock weather when API is unreachable."""
+    temp = random.randint(50, 90)
+    condition = random.choice(["sunny", "cloudy", "rainy", "partly cloudy"])
+    return {
+        "location": location,
+        "temperature": f"{temp}°F",
+        "condition": condition,
+        "wind_speed": f"{random.randint(0, 25)} mph",
+        "source": "fallback",
+    }
+
+
+def _fallback_attractions(destination: str) -> dict:
+    """Fallback mock attractions when Wikipedia is unreachable."""
+    events = [
+        {"name": f"{destination} City Tour", "type": "tour", "venue": destination},
+        {"name": f"{destination} Food Festival", "type": "food", "venue": destination},
+        {"name": f"Live Music in {destination}", "type": "music", "venue": destination},
+    ]
+    return {"destination": destination, "events": random.sample(events, k=random.randint(1, 3)), "source": "fallback"}
+
+
+def _fallback_currency(amount: float, from_currency: str, to_currency: str) -> dict:
+    """Fallback with approximate rates when Frankfurter is unreachable."""
+    approx_rates = {"EUR": 0.92, "GBP": 0.79, "JPY": 155.0, "CAD": 1.36, "AUD": 1.53, "INR": 83.5}
+    rate = approx_rates.get(to_currency.upper(), 1.0)
+    if from_currency.upper() != "USD":
+        from_rate = approx_rates.get(from_currency.upper(), 1.0)
+        rate = rate / from_rate
+    return {
+        "amount": amount,
+        "from_currency": from_currency.upper(),
+        "to_currency": to_currency.upper(),
+        "converted": round(amount * rate, 2),
+        "rate": rate,
+        "date": "approximate",
+        "source": "fallback",
+    }
+
+
+async def execute_tool(name: str, args: dict, span) -> dict:
+    """Execute tool with real API, falling back to mock on failure."""
     if name == "fetch_weather_api":
         location = args.get("location", "Unknown")
-        temp = random.randint(50, 90)
-        condition = random.choice(["sunny", "cloudy", "rainy", "partly cloudy"])
-        return {
-            "location": location,
-            "temperature": f"{temp}°F",
-            "condition": condition,
-            "humidity": f"{random.randint(30, 80)}%",
-            "wind_speed": f"{random.randint(0, 25)} mph",
-        }
+        try:
+            result = await fetch_weather(location)
+        except Exception as e:
+            span.set_attribute("tool.fallback", True)
+            span.set_attribute("tool.fallback.reason", str(e)[:200])
+            result = _fallback_weather(location)
+        return result
 
     elif name == "fetch_events_api":
         destination = args.get("destination", "Unknown")
-        events = [
-            {"name": f"{destination} Food Festival", "date": "2025-03-15", "type": "food"},
-            {"name": f"{destination} Art Walk", "date": "2025-03-20", "type": "art"},
-            {"name": f"Live Music at {destination} Park", "date": "2025-03-22", "type": "music"},
-        ]
-        return {"destination": destination, "events": random.sample(events, k=random.randint(1, 3))}
+        try:
+            result = await fetch_attractions(destination)
+        except Exception as e:
+            span.set_attribute("tool.fallback", True)
+            span.set_attribute("tool.fallback.reason", str(e)[:200])
+            result = _fallback_attractions(destination)
+        return result
+
+    elif name == "fetch_flights_api":
+        origin = args.get("origin", "Unknown")
+        destination = args.get("destination", "Unknown")
+        date = args.get("date")
+        result = await fetch_flights(origin, destination, date)
+        return result
+
+    elif name == "convert_currency":
+        amount = args.get("amount", 100)
+        from_currency = args.get("from_currency", "USD")
+        to_currency = args.get("to_currency", "EUR")
+        try:
+            result = await convert_currency_api(amount, from_currency, to_currency)
+        except Exception as e:
+            span.set_attribute("tool.fallback", True)
+            span.set_attribute("tool.fallback.reason", str(e)[:200])
+            result = _fallback_currency(amount, from_currency, to_currency)
+        return result
 
     else:
         raise ValueError(f"Unknown tool: {name}")

--- a/examples/plain-agents/multi-agent-planner/orchestrator/Dockerfile
+++ b/examples/plain-agents/multi-agent-planner/orchestrator/Dockerfile
@@ -7,6 +7,8 @@ RUN pip install --no-cache-dir \
     fastapi \
     uvicorn \
     httpx \
+    requests \
+    boto3 \
     opensearch-genai-observability-sdk-py>=0.2.7 \
     opentelemetry-exporter-otlp-proto-grpc \
     opentelemetry-instrumentation-httpx \

--- a/examples/plain-agents/multi-agent-planner/orchestrator/bedrock_client.py
+++ b/examples/plain-agents/multi-agent-planner/orchestrator/bedrock_client.py
@@ -13,7 +13,7 @@ from botocore.exceptions import ClientError, NoCredentialsError, EndpointConnect
 
 logger = logging.getLogger(__name__)
 
-BEDROCK_MODEL_ID = os.getenv("BEDROCK_MODEL_ID", "us.anthropic.claude-opus-4-8")
+BEDROCK_MODEL_ID = os.getenv("BEDROCK_MODEL_ID", "global.anthropic.claude-haiku-4-5-20251001-v1:0")
 BEDROCK_REGION = os.getenv("AWS_REGION", os.getenv("AWS_DEFAULT_REGION", "us-west-2"))
 
 

--- a/examples/plain-agents/multi-agent-planner/orchestrator/bedrock_client.py
+++ b/examples/plain-agents/multi-agent-planner/orchestrator/bedrock_client.py
@@ -1,0 +1,121 @@
+"""
+Amazon Bedrock Converse API client for real LLM calls.
+Uses boto3 with the default credential chain (env vars, ~/.aws/credentials, instance role).
+"""
+
+import json
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+import boto3
+from botocore.exceptions import ClientError, NoCredentialsError, EndpointConnectionError
+
+logger = logging.getLogger(__name__)
+
+BEDROCK_MODEL_ID = os.getenv("BEDROCK_MODEL_ID", "us.anthropic.claude-opus-4-8")
+BEDROCK_REGION = os.getenv("AWS_REGION", os.getenv("AWS_DEFAULT_REGION", "us-west-2"))
+
+
+class BedrockUnavailableError(Exception):
+    pass
+
+
+def get_bedrock_client():
+    """Create Bedrock Runtime client. Returns None if credentials are missing."""
+    try:
+        client = boto3.client("bedrock-runtime", region_name=BEDROCK_REGION)
+        return client
+    except (NoCredentialsError, Exception) as e:
+        logger.warning(f"Bedrock client init failed: {e}")
+        return None
+
+
+def openai_tools_to_bedrock(tools: List[Dict]) -> Dict:
+    """Convert OpenAI-style tool definitions to Bedrock toolConfig format."""
+    bedrock_tools = []
+    for tool in tools:
+        func = tool.get("function", tool)
+        bedrock_tools.append({
+            "toolSpec": {
+                "name": func["name"],
+                "description": func.get("description", ""),
+                "inputSchema": {
+                    "json": func.get("parameters", {"type": "object", "properties": {}})
+                }
+            }
+        })
+    return {"tools": bedrock_tools}
+
+
+def converse(
+    client,
+    messages: List[Dict[str, Any]],
+    system: Optional[str] = None,
+    tool_config: Optional[Dict] = None,
+    model_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """
+    Call Bedrock Converse API.
+
+    Args:
+        client: boto3 bedrock-runtime client
+        messages: Bedrock message format [{"role": "user", "content": [{"text": "..."}]}]
+        system: Optional system prompt
+        tool_config: Optional Bedrock toolConfig dict
+        model_id: Model to use (defaults to BEDROCK_MODEL_ID)
+
+    Returns:
+        Full Converse API response dict with output, usage, stopReason
+
+    Raises:
+        BedrockUnavailableError on credential/throttle/connection issues
+    """
+    kwargs = {
+        "modelId": model_id or BEDROCK_MODEL_ID,
+        "messages": messages,
+    }
+    if system:
+        kwargs["system"] = [{"text": system}]
+    if tool_config:
+        kwargs["toolConfig"] = tool_config
+
+    try:
+        response = client.converse(**kwargs)
+        return response
+    except NoCredentialsError as e:
+        raise BedrockUnavailableError(f"No AWS credentials: {e}")
+    except EndpointConnectionError as e:
+        raise BedrockUnavailableError(f"Cannot reach Bedrock endpoint: {e}")
+    except ClientError as e:
+        error_code = e.response["Error"]["Code"]
+        if error_code in ("ThrottlingException", "ServiceUnavailableException", "AccessDeniedException", "ValidationException"):
+            raise BedrockUnavailableError(f"Bedrock error: {error_code} - {e.response['Error']['Message']}")
+        raise
+
+
+def extract_text(response: Dict) -> str:
+    """Extract text content from a Converse API response."""
+    message = response.get("output", {}).get("message", {})
+    for block in message.get("content", []):
+        if "text" in block:
+            return block["text"]
+    return ""
+
+
+def extract_tool_use(response: Dict) -> Optional[Dict]:
+    """Extract the first toolUse block from a Converse API response."""
+    message = response.get("output", {}).get("message", {})
+    for block in message.get("content", []):
+        if "toolUse" in block:
+            return block["toolUse"]
+    return None
+
+
+def get_usage(response: Dict) -> Dict[str, int]:
+    """Extract token usage from response."""
+    usage = response.get("usage", {})
+    return {
+        "input_tokens": usage.get("inputTokens", 0),
+        "output_tokens": usage.get("outputTokens", 0),
+    }

--- a/examples/plain-agents/multi-agent-planner/orchestrator/main.py
+++ b/examples/plain-agents/multi-agent-planner/orchestrator/main.py
@@ -12,11 +12,13 @@ import asyncio
 import json
 import os
 import random
+import threading
 import time
 from typing import Optional
 from uuid import uuid4
 
 import httpx
+import requests
 from fastapi import FastAPI
 from opentelemetry import trace, metrics
 from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
@@ -30,6 +32,10 @@ from opentelemetry.propagate import inject
 from pydantic import BaseModel, Field
 
 from opensearch_genai_observability_sdk_py import Op, enrich, observe, register
+from bedrock_client import (
+    get_bedrock_client, converse, extract_text, get_usage,
+    openai_tools_to_bedrock, BedrockUnavailableError, BEDROCK_MODEL_ID,
+)
 
 
 AGENT_ID = "travel-planner-001"
@@ -38,6 +44,27 @@ AGENT_NAME = "Travel Planner"
 WEATHER_AGENT_URL = os.getenv("WEATHER_AGENT_URL", "http://weather-agent:8000")
 EVENTS_AGENT_URL = os.getenv("EVENTS_AGENT_URL", "http://events-agent:8002")
 MCP_SERVER_URL = os.getenv("MCP_SERVER_URL", "http://mcp-server:8003")
+FAULT_PANEL_URL = os.getenv("FAULT_PANEL_URL", "http://fault-panel:8085")
+
+# Config cache — polled from fault panel
+_config_cache = {"use_real_llm": False}
+
+
+def _poll_config():
+    while True:
+        try:
+            resp = requests.get(f"{FAULT_PANEL_URL}/config", timeout=2)
+            if resp.status_code == 200:
+                _config_cache["use_real_llm"] = resp.json().get("use_real_llm", False)
+        except Exception:
+            pass
+        time.sleep(30)
+
+
+threading.Thread(target=_poll_config, daemon=True).start()
+
+# Bedrock client (None if no creds available)
+_bedrock_client = get_bedrock_client()
 
 TOOL_DEFINITIONS = [
     {
@@ -185,6 +212,10 @@ async def call_mcp_tool(tool_name: str, arguments: dict) -> dict:
         span.set_attribute("jsonrpc.request.id", request_id)
         span.set_attribute("gen_ai.tool.name", tool_name)
 
+        enrich(
+            input_messages=[{"role": "tool_call", "parts": [{"type": "text", "content": json.dumps(arguments)}]}],
+        )
+
         headers = {"mcp-session-id": session_id}
         inject(headers)
         payload = {
@@ -196,7 +227,11 @@ async def call_mcp_tool(tool_name: str, arguments: dict) -> dict:
             result = resp.json()
             if "error" in result:
                 raise Exception(result["error"].get("message", "MCP tool call failed"))
-            return result.get("result", {})
+            tool_result = result.get("result", {})
+            enrich(
+                output_messages=[{"role": "tool_result", "parts": [{"type": "text", "content": json.dumps(tool_result)}]}],
+            )
+            return tool_result
 
 
 @inner_app.post("/plan")
@@ -230,16 +265,33 @@ async def plan_trip(request: PlanRequest):
         flights_data = None
         currency_data = None
 
-        # Synthetic "thinking" LLM call
-        with observe("planning", op=Op.CHAT):
-            enrich(
-                model=model,
-                provider=provider,
-                input_tokens=random.randint(500, 2000),
-                output_tokens=random.randint(100, 500),
-                finish_reason="tool_calls",
-            )
-            time.sleep(random.uniform(0.1, 0.3))
+        # LLM planning call
+        with observe("planning", op=Op.CHAT) as planning_span:
+            if _config_cache["use_real_llm"] and _bedrock_client:
+                try:
+                    planning_messages = [{"role": "user", "content": [{"text": f"Plan a weekend trip to {request.destination}. What information should we gather about weather, attractions, flights, and currency?"}]}]
+                    planning_response = converse(
+                        _bedrock_client, planning_messages,
+                        system="You are a travel planning assistant. Briefly outline what to research for this trip.",
+                    )
+                    usage = get_usage(planning_response)
+                    enrich(
+                        model=BEDROCK_MODEL_ID,
+                        provider="aws_bedrock",
+                        input_tokens=usage["input_tokens"],
+                        output_tokens=usage["output_tokens"],
+                        finish_reason=planning_response.get("stopReason", "end_turn"),
+                        input_messages=[{"role": "user", "parts": [{"type": "text", "content": f"Plan a trip to {request.destination}"}]}],
+                        output_messages=[{"role": "assistant", "parts": [{"type": "text", "content": extract_text(planning_response)}]}],
+                    )
+                except BedrockUnavailableError as e:
+                    planning_span.set_attribute("gen_ai.bedrock.fallback", True)
+                    planning_span.set_attribute("gen_ai.bedrock.fallback.reason", str(e)[:200])
+                    enrich(model=model, provider=provider, input_tokens=random.randint(500, 2000), output_tokens=random.randint(100, 500), finish_reason="tool_calls")
+                    time.sleep(random.uniform(0.1, 0.3))
+            else:
+                enrich(model=model, provider=provider, input_tokens=random.randint(500, 2000), output_tokens=random.randint(100, 500), finish_reason="tool_calls")
+                time.sleep(random.uniform(0.1, 0.3))
 
         # Build sub-agent payloads with fault pass-through
         weather_payload = {"message": f"What's the weather in {request.destination}?"}
@@ -317,16 +369,37 @@ async def plan_trip(request: PlanRequest):
             except Exception as e:
                 errors.append({"agent": "currency", "error": str(e)})
 
-        # Final response "chat" span
-        with observe("summarize", op=Op.CHAT):
-            enrich(
-                model=model,
-                provider=provider,
-                input_tokens=random.randint(200, 800),
-                output_tokens=random.randint(50, 200),
-                finish_reason="stop",
-            )
-            time.sleep(random.uniform(0.05, 0.15))
+        # Final response "chat" span — summarize gathered data
+        with observe("summarize", op=Op.CHAT) as summarize_span:
+            gathered = {"destination": request.destination, "weather": weather_data, "events": events_data, "flights": flights_data, "currency": currency_data}
+            if _config_cache["use_real_llm"] and _bedrock_client:
+                try:
+                    summary_messages = [{"role": "user", "content": [{"text": f"Summarize this trip data into a brief recommendation (2-3 sentences):\n{json.dumps(gathered, default=str)}"}]}]
+                    summary_response = converse(
+                        _bedrock_client, summary_messages,
+                        system="You are a travel assistant. Give a concise, enthusiastic trip recommendation based on the gathered data.",
+                    )
+                    usage = get_usage(summary_response)
+                    recommendation = extract_text(summary_response)
+                    enrich(
+                        model=BEDROCK_MODEL_ID,
+                        provider="aws_bedrock",
+                        input_tokens=usage["input_tokens"],
+                        output_tokens=usage["output_tokens"],
+                        finish_reason=summary_response.get("stopReason", "end_turn"),
+                        input_messages=[{"role": "user", "parts": [{"type": "text", "content": json.dumps(gathered, default=str)}]}],
+                        output_messages=[{"role": "assistant", "parts": [{"type": "text", "content": recommendation}]}],
+                    )
+                except BedrockUnavailableError as e:
+                    summarize_span.set_attribute("gen_ai.bedrock.fallback", True)
+                    summarize_span.set_attribute("gen_ai.bedrock.fallback.reason", str(e)[:200])
+                    recommendation = None
+                    enrich(model=model, provider=provider, input_tokens=random.randint(200, 800), output_tokens=random.randint(50, 200), finish_reason="stop")
+                    time.sleep(random.uniform(0.05, 0.15))
+            else:
+                recommendation = None
+                enrich(model=model, provider=provider, input_tokens=random.randint(200, 800), output_tokens=random.randint(50, 200), finish_reason="stop")
+                time.sleep(random.uniform(0.05, 0.15))
 
         partial = len(errors) > 0
         if partial:
@@ -337,7 +410,8 @@ async def plan_trip(request: PlanRequest):
                 span.set_attribute(f"response.error_{i}_message", str(err["error"])[:200])
             span.set_status(Status(StatusCode.ERROR, f"Partial failure: {len(errors)} sub-agent(s) failed"))
 
-        recommendation = build_recommendation(request.destination, weather_data, events_data, flights_data, currency_data, partial)
+        if not recommendation:
+            recommendation = build_recommendation(request.destination, weather_data, events_data, flights_data, currency_data, partial)
 
     enrich(
         output_messages=[{"role": "assistant", "parts": [{"type": "text", "content": recommendation}]}],

--- a/examples/plain-agents/multi-agent-planner/orchestrator/main.py
+++ b/examples/plain-agents/multi-agent-planner/orchestrator/main.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Travel Planner - Orchestrates weather and events agents.
+Travel Planner - Orchestrates weather, events, flights, and currency agents.
 Supports fault injection at orchestrator level and pass-through to sub-agents.
 
 Instrumented with opensearch-genai-observability-sdk-py:
@@ -14,6 +14,7 @@ import os
 import random
 import time
 from typing import Optional
+from uuid import uuid4
 
 import httpx
 from fastapi import FastAPI
@@ -25,6 +26,7 @@ from opentelemetry.sdk.resources import Resource
 from opentelemetry.trace import SpanKind, Status, StatusCode
 from opentelemetry.instrumentation.asgi import OpenTelemetryMiddleware
 from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
+from opentelemetry.propagate import inject
 from pydantic import BaseModel, Field
 
 from opensearch_genai_observability_sdk_py import Op, enrich, observe, register
@@ -35,14 +37,14 @@ AGENT_NAME = "Travel Planner"
 
 WEATHER_AGENT_URL = os.getenv("WEATHER_AGENT_URL", "http://weather-agent:8000")
 EVENTS_AGENT_URL = os.getenv("EVENTS_AGENT_URL", "http://events-agent:8002")
+MCP_SERVER_URL = os.getenv("MCP_SERVER_URL", "http://mcp-server:8003")
 
-# Tool definitions for this agent
 TOOL_DEFINITIONS = [
     {
         "type": "function",
         "function": {
             "name": "get_weather",
-            "description": "Get weather information for a destination by calling the weather agent",
+            "description": "Get current weather for a destination (real Open-Meteo data)",
             "parameters": {"type": "object", "properties": {"destination": {"type": "string"}}, "required": ["destination"]}
         }
     },
@@ -50,13 +52,44 @@ TOOL_DEFINITIONS = [
         "type": "function",
         "function": {
             "name": "get_events",
-            "description": "Get local events for a destination by calling the events agent",
+            "description": "Get attractions and points of interest from Wikipedia",
             "parameters": {"type": "object", "properties": {"destination": {"type": "string"}}, "required": ["destination"]}
+        }
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_flights",
+            "description": "Search for flights between origin and destination",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "origin": {"type": "string"},
+                    "destination": {"type": "string"},
+                    "date": {"type": "string", "description": "YYYY-MM-DD"}
+                },
+                "required": ["origin", "destination"]
+            }
+        }
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "convert_currency",
+            "description": "Convert amount between currencies using live ECB rates",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "amount": {"type": "number"},
+                    "from_currency": {"type": "string"},
+                    "to_currency": {"type": "string"}
+                },
+                "required": ["amount", "from_currency", "to_currency"]
+            }
         }
     }
 ]
 
-# Model rotation for realistic traces
 MODELS = [
     "claude-opus-4.5", "claude-sonnet-4.5", "claude-haiku-4.5", "claude-sonnet-4", "claude-haiku",
     "gpt-5", "gpt-4.1", "gpt-4.1-mini", "gpt-4o", "gpt-4o-mini", "o4-mini",
@@ -72,6 +105,15 @@ SYSTEMS = {
     "nova-2-pro": "amazon", "nova-2-lite": "amazon", "nova-premier": "amazon",
     "nova-pro": "amazon", "nova-lite": "amazon",
 }
+
+DESTINATION_CURRENCIES = {
+    "paris": "EUR", "london": "GBP", "tokyo": "JPY", "berlin": "EUR",
+    "sydney": "AUD", "mumbai": "INR", "toronto": "CAD", "seattle": "USD",
+    "new york": "USD", "portland": "USD", "vancouver": "CAD", "rome": "EUR",
+    "barcelona": "EUR", "amsterdam": "EUR", "bangkok": "THB",
+}
+
+MCP_PROTOCOL_VERSION = "2025-06-18"
 
 
 class SubAgentFault(BaseModel):
@@ -89,6 +131,7 @@ class FaultConfig(BaseModel):
 
 class PlanRequest(BaseModel):
     destination: str
+    origin: Optional[str] = None
     fault: Optional[FaultConfig] = None
 
 
@@ -96,24 +139,22 @@ class PlanResponse(BaseModel):
     destination: str
     weather: Optional[dict] = None
     events: list = []
+    flights: Optional[dict] = None
+    currency: Optional[dict] = None
     recommendation: str
     partial: bool = False
     errors: list = []
 
 
 # --- Telemetry setup ---
-# SDK handles tracing; metrics still need manual setup
 otlp_endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
 
-# One line replaces ~20 lines of TracerProvider + exporter setup
 register(
     endpoint=f"grpc://{otlp_endpoint.replace('http://', '').replace('https://', '')}",
     service_name="travel-planner",
     service_version="1.0.0",
 )
 
-# Metrics (SDK handles tracing only)
-# TODO: unify Resource with register() when SDK supports metrics
 resource = Resource.create({"service.name": "travel-planner"})
 metric_reader = PeriodicExportingMetricReader(
     OTLPMetricExporter(endpoint=otlp_endpoint, insecure=True),
@@ -122,9 +163,7 @@ metric_reader = PeriodicExportingMetricReader(
 meter_provider = MeterProvider(resource=resource, metric_readers=[metric_reader])
 metrics.set_meter_provider(meter_provider)
 
-# HTTPx auto-instrumentation for outbound calls
 HTTPXClientInstrumentor().instrument()
-
 
 inner_app = FastAPI(title="Travel Planner", version="1.0.0")
 
@@ -134,19 +173,43 @@ async def health():
     return {"status": "healthy", "agent_id": AGENT_ID, "agent_name": AGENT_NAME}
 
 
+async def call_mcp_tool(tool_name: str, arguments: dict) -> dict:
+    """Call MCP server directly for a tool execution."""
+    session_id = uuid4().hex
+    request_id = uuid4().hex[:8]
+
+    with observe(f"tools/call {tool_name}", op=Op.EXECUTE_TOOL, kind=SpanKind.CLIENT) as span:
+        span.set_attribute("mcp.method.name", "tools/call")
+        span.set_attribute("mcp.session.id", session_id)
+        span.set_attribute("mcp.protocol.version", MCP_PROTOCOL_VERSION)
+        span.set_attribute("jsonrpc.request.id", request_id)
+        span.set_attribute("gen_ai.tool.name", tool_name)
+
+        headers = {"mcp-session-id": session_id}
+        inject(headers)
+        payload = {
+            "jsonrpc": "2.0", "method": "tools/call", "id": request_id,
+            "params": {"name": tool_name, "arguments": arguments}
+        }
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            resp = await client.post(f"{MCP_SERVER_URL}/mcp", json=payload, headers=headers)
+            result = resp.json()
+            if "error" in result:
+                raise Exception(result["error"].get("message", "MCP tool call failed"))
+            return result.get("result", {})
+
+
 @inner_app.post("/plan")
 async def plan_trip(request: PlanRequest):
     model = random.choice(MODELS)
     provider = SYSTEMS[model]
 
-    # Promote gen_ai attributes to the root HTTP span so the UI can read them
     enrich(
         model=model,
         provider=provider,
         agent_id=AGENT_ID,
         input_messages=[{"role": "user", "parts": [{"type": "text", "content": f"Plan a trip to {request.destination}"}]}],
     )
-    # Set agent name and operation on the root span directly
     root_span = trace.get_current_span()
     root_span.set_attribute("gen_ai.agent.name", AGENT_NAME)
     root_span.set_attribute("gen_ai.operation.name", "invoke_agent")
@@ -164,6 +227,8 @@ async def plan_trip(request: PlanRequest):
         errors = []
         weather_data = None
         events_data = []
+        flights_data = None
+        currency_data = None
 
         # Synthetic "thinking" LLM call
         with observe("planning", op=Op.CHAT):
@@ -193,9 +258,8 @@ async def plan_trip(request: PlanRequest):
         else:
             timeout = 30.0
 
-        # Fan out to sub-agents
+        # Fan out to sub-agents (weather + events in parallel)
         async with httpx.AsyncClient(timeout=timeout) as client:
-            # Invoke weather agent
             with observe("weather-agent", op=Op.INVOKE_AGENT, kind=SpanKind.CLIENT) as agent_span:
                 agent_span.set_attribute("gen_ai.agent.name", "weather-agent")
                 try:
@@ -211,7 +275,6 @@ async def plan_trip(request: PlanRequest):
                     errors.append({"agent": "weather", "error": str(e)})
                     agent_span.set_status(Status(StatusCode.ERROR, str(e)))
 
-            # Invoke events agent
             with observe("events-agent", op=Op.INVOKE_AGENT, kind=SpanKind.CLIENT) as agent_span:
                 agent_span.set_attribute("gen_ai.agent.name", "events-agent")
                 try:
@@ -232,6 +295,28 @@ async def plan_trip(request: PlanRequest):
                     errors.append({"agent": "events", "error": str(e)})
                     agent_span.set_status(Status(StatusCode.ERROR, str(e)))
 
+        # Sequential MCP calls for flights and currency (produces deeper trace waterfall)
+        origin = request.origin or "Portland"
+        try:
+            flights_data = await call_mcp_tool("fetch_flights_api", {
+                "origin": origin,
+                "destination": request.destination,
+            })
+        except Exception as e:
+            errors.append({"agent": "flights", "error": str(e)})
+
+        dest_lower = request.destination.lower()
+        target_currency = DESTINATION_CURRENCIES.get(dest_lower, "EUR")
+        if target_currency != "USD":
+            try:
+                currency_data = await call_mcp_tool("convert_currency", {
+                    "amount": 100,
+                    "from_currency": "USD",
+                    "to_currency": target_currency,
+                })
+            except Exception as e:
+                errors.append({"agent": "currency", "error": str(e)})
+
         # Final response "chat" span
         with observe("summarize", op=Op.CHAT):
             enrich(
@@ -243,7 +328,6 @@ async def plan_trip(request: PlanRequest):
             )
             time.sleep(random.uniform(0.05, 0.15))
 
-        # Build recommendation with graceful degradation
         partial = len(errors) > 0
         if partial:
             span.set_attribute("response.partial", True)
@@ -253,11 +337,8 @@ async def plan_trip(request: PlanRequest):
                 span.set_attribute(f"response.error_{i}_message", str(err["error"])[:200])
             span.set_status(Status(StatusCode.ERROR, f"Partial failure: {len(errors)} sub-agent(s) failed"))
 
-        recommendation = build_recommendation(request.destination, weather_data, events_data, partial)
+        recommendation = build_recommendation(request.destination, weather_data, events_data, flights_data, currency_data, partial)
 
-    # Set output on the parent HTTP request span. This enrich() is intentionally
-    # outside the observe() block — exiting observe() restores the parent span
-    # context, so enrich() here targets the HTTP request span, not the agent span.
     enrich(
         output_messages=[{"role": "assistant", "parts": [{"type": "text", "content": recommendation}]}],
     )
@@ -266,25 +347,38 @@ async def plan_trip(request: PlanRequest):
         destination=request.destination,
         weather=weather_data,
         events=events_data,
+        flights=flights_data,
+        currency=currency_data,
         recommendation=recommendation,
         partial=partial,
         errors=errors,
     )
 
 
-def build_recommendation(destination: str, weather: Optional[dict], events: list, partial: bool) -> str:
+def build_recommendation(destination: str, weather: Optional[dict], events: list,
+                         flights: Optional[dict], currency: Optional[dict], partial: bool) -> str:
     parts = [f"Great choice! {destination} looks wonderful."]
 
     if weather and "response" in weather:
         parts.append(weather["response"])
+    elif weather and "temperature" in str(weather):
+        parts.append(f"Current weather: expect conditions around there.")
     elif partial:
         parts.append("Weather info temporarily unavailable.")
 
     if events:
-        event_names = [e["name"] for e in events[:2]]
-        parts.append(f"Check out {', '.join(event_names)}.")
+        event_names = [e["name"] if isinstance(e, dict) else str(e) for e in events[:3]]
+        parts.append(f"Don't miss: {', '.join(event_names)}.")
     elif partial:
-        parts.append("Events info temporarily unavailable.")
+        parts.append("Attractions info temporarily unavailable.")
+
+    if flights and "flights" in flights:
+        cheapest = flights["flights"][0] if flights["flights"] else None
+        if cheapest:
+            parts.append(f"Flights from ${cheapest['price_usd']} ({cheapest['airline']}).")
+
+    if currency:
+        parts.append(f"$100 USD ≈ {currency['converted']} {currency['to_currency']}.")
 
     return " ".join(parts)
 

--- a/examples/plain-agents/weather-agent/Dockerfile
+++ b/examples/plain-agents/weather-agent/Dockerfile
@@ -10,6 +10,8 @@ RUN pip install --no-cache-dir \
     fastapi \
     uvicorn \
     httpx \
+    requests \
+    boto3 \
     opensearch-genai-observability-sdk-py>=0.2.7 \
     opentelemetry-exporter-otlp-proto-grpc \
     opentelemetry-instrumentation-asgi

--- a/examples/plain-agents/weather-agent/bedrock_client.py
+++ b/examples/plain-agents/weather-agent/bedrock_client.py
@@ -13,7 +13,7 @@ from botocore.exceptions import ClientError, NoCredentialsError, EndpointConnect
 
 logger = logging.getLogger(__name__)
 
-BEDROCK_MODEL_ID = os.getenv("BEDROCK_MODEL_ID", "us.anthropic.claude-opus-4-8")
+BEDROCK_MODEL_ID = os.getenv("BEDROCK_MODEL_ID", "global.anthropic.claude-haiku-4-5-20251001-v1:0")
 BEDROCK_REGION = os.getenv("AWS_REGION", os.getenv("AWS_DEFAULT_REGION", "us-west-2"))
 
 

--- a/examples/plain-agents/weather-agent/bedrock_client.py
+++ b/examples/plain-agents/weather-agent/bedrock_client.py
@@ -1,0 +1,121 @@
+"""
+Amazon Bedrock Converse API client for real LLM calls.
+Uses boto3 with the default credential chain (env vars, ~/.aws/credentials, instance role).
+"""
+
+import json
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+import boto3
+from botocore.exceptions import ClientError, NoCredentialsError, EndpointConnectionError
+
+logger = logging.getLogger(__name__)
+
+BEDROCK_MODEL_ID = os.getenv("BEDROCK_MODEL_ID", "us.anthropic.claude-opus-4-8")
+BEDROCK_REGION = os.getenv("AWS_REGION", os.getenv("AWS_DEFAULT_REGION", "us-west-2"))
+
+
+class BedrockUnavailableError(Exception):
+    pass
+
+
+def get_bedrock_client():
+    """Create Bedrock Runtime client. Returns None if credentials are missing."""
+    try:
+        client = boto3.client("bedrock-runtime", region_name=BEDROCK_REGION)
+        return client
+    except (NoCredentialsError, Exception) as e:
+        logger.warning(f"Bedrock client init failed: {e}")
+        return None
+
+
+def openai_tools_to_bedrock(tools: List[Dict]) -> Dict:
+    """Convert OpenAI-style tool definitions to Bedrock toolConfig format."""
+    bedrock_tools = []
+    for tool in tools:
+        func = tool.get("function", tool)
+        bedrock_tools.append({
+            "toolSpec": {
+                "name": func["name"],
+                "description": func.get("description", ""),
+                "inputSchema": {
+                    "json": func.get("parameters", {"type": "object", "properties": {}})
+                }
+            }
+        })
+    return {"tools": bedrock_tools}
+
+
+def converse(
+    client,
+    messages: List[Dict[str, Any]],
+    system: Optional[str] = None,
+    tool_config: Optional[Dict] = None,
+    model_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """
+    Call Bedrock Converse API.
+
+    Args:
+        client: boto3 bedrock-runtime client
+        messages: Bedrock message format [{"role": "user", "content": [{"text": "..."}]}]
+        system: Optional system prompt
+        tool_config: Optional Bedrock toolConfig dict
+        model_id: Model to use (defaults to BEDROCK_MODEL_ID)
+
+    Returns:
+        Full Converse API response dict with output, usage, stopReason
+
+    Raises:
+        BedrockUnavailableError on credential/throttle/connection issues
+    """
+    kwargs = {
+        "modelId": model_id or BEDROCK_MODEL_ID,
+        "messages": messages,
+    }
+    if system:
+        kwargs["system"] = [{"text": system}]
+    if tool_config:
+        kwargs["toolConfig"] = tool_config
+
+    try:
+        response = client.converse(**kwargs)
+        return response
+    except NoCredentialsError as e:
+        raise BedrockUnavailableError(f"No AWS credentials: {e}")
+    except EndpointConnectionError as e:
+        raise BedrockUnavailableError(f"Cannot reach Bedrock endpoint: {e}")
+    except ClientError as e:
+        error_code = e.response["Error"]["Code"]
+        if error_code in ("ThrottlingException", "ServiceUnavailableException", "AccessDeniedException", "ValidationException"):
+            raise BedrockUnavailableError(f"Bedrock error: {error_code} - {e.response['Error']['Message']}")
+        raise
+
+
+def extract_text(response: Dict) -> str:
+    """Extract text content from a Converse API response."""
+    message = response.get("output", {}).get("message", {})
+    for block in message.get("content", []):
+        if "text" in block:
+            return block["text"]
+    return ""
+
+
+def extract_tool_use(response: Dict) -> Optional[Dict]:
+    """Extract the first toolUse block from a Converse API response."""
+    message = response.get("output", {}).get("message", {})
+    for block in message.get("content", []):
+        if "toolUse" in block:
+            return block["toolUse"]
+    return None
+
+
+def get_usage(response: Dict) -> Dict[str, int]:
+    """Extract token usage from response."""
+    usage = response.get("usage", {})
+    return {
+        "input_tokens": usage.get("inputTokens", 0),
+        "output_tokens": usage.get("outputTokens", 0),
+    }

--- a/examples/plain-agents/weather-agent/main.py
+++ b/examples/plain-agents/weather-agent/main.py
@@ -527,12 +527,16 @@ class WeatherAgent:
                     {"role": "assistant", "parts": [{"type": "text", "content": final_response}], "finish_reason": "stop"}
                 ])
 
+                response_id = llm_response["id"] if "llm_response" in dir() and llm_response else f"bedrock-{uuid4().hex[:8]}"
+                response_model = llm_response["model"] if "llm_response" in dir() and llm_response else BEDROCK_MODEL_ID
+                provider_name = "aws_bedrock" if (_config_cache["use_real_llm"] and _bedrock_client) else "openai"
+
                 self.logger.info(
                     "Agent invocation completed",
                     extra={
                         "gen_ai.operation.name": "invoke_agent",
                         "gen_ai.agent.id": self.agent_id,
-                        "gen_ai.response.id": llm_response["id"],
+                        "gen_ai.response.id": response_id,
                         "gen_ai.conversation.id": conversation_id,
                         "response": final_response
                     }
@@ -543,10 +547,10 @@ class WeatherAgent:
                     duration,
                     attributes={
                         "gen_ai.operation.name": "invoke_agent",
-                        "gen_ai.provider.name": "openai",
-                        "gen_ai.request.model": self.model,
-                        "gen_ai.response.model": llm_response["model"],
-                        "server.address": "api.openai.com"
+                        "gen_ai.provider.name": provider_name,
+                        "gen_ai.request.model": BEDROCK_MODEL_ID if provider_name == "aws_bedrock" else self.model,
+                        "gen_ai.response.model": response_model,
+                        "server.address": "bedrock-runtime.us-west-2.amazonaws.com" if provider_name == "aws_bedrock" else "api.openai.com"
                     }
                 )
 

--- a/examples/plain-agents/weather-agent/main.py
+++ b/examples/plain-agents/weather-agent/main.py
@@ -19,11 +19,13 @@ import json
 import logging
 import os
 import random
+import threading
 import time
 from typing import Dict, Any, List, Optional
 from uuid import uuid4
 
 import httpx
+import requests as req_lib
 from opentelemetry import trace, metrics
 from opentelemetry.trace import SpanKind, Status, StatusCode
 from opentelemetry.propagate import inject
@@ -37,6 +39,29 @@ from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
 from opentelemetry.exporter.otlp.proto.grpc._log_exporter import OTLPLogExporter
 
 from opensearch_genai_observability_sdk_py import Op, enrich, observe, register
+from bedrock_client import (
+    get_bedrock_client, converse, extract_text, extract_tool_use, get_usage,
+    openai_tools_to_bedrock, BedrockUnavailableError, BEDROCK_MODEL_ID,
+)
+
+FAULT_PANEL_URL = os.getenv("FAULT_PANEL_URL", "http://fault-panel:8085")
+_config_cache = {"use_real_llm": False}
+
+
+def _poll_config():
+    while True:
+        try:
+            resp = req_lib.get(f"{FAULT_PANEL_URL}/config", timeout=2)
+            if resp.status_code == 200:
+                _config_cache["use_real_llm"] = resp.json().get("use_real_llm", False)
+        except Exception:
+            pass
+        time.sleep(30)
+
+
+threading.Thread(target=_poll_config, daemon=True).start()
+
+_bedrock_client = get_bedrock_client()
 
 
 # Fault injection exceptions
@@ -390,84 +415,112 @@ class WeatherAgent:
                     {"role": "user", "content": user_message}
                 ]
 
-                llm_response = call_llm(self.model, messages, self.tools)
+                # --- Bedrock path (real LLM) ---
+                if _config_cache["use_real_llm"] and _bedrock_client:
+                    try:
+                        bedrock_messages = [{"role": "user", "content": [{"text": user_message}]}]
+                        tool_config = openai_tools_to_bedrock(self.tools)
+                        bedrock_response = converse(
+                            _bedrock_client, bedrock_messages,
+                            system=system_instructions[0]["content"],
+                            tool_config=tool_config,
+                        )
+                        usage = get_usage(bedrock_response)
+                        enrich(
+                            model=BEDROCK_MODEL_ID,
+                            provider="aws_bedrock",
+                            input_tokens=usage["input_tokens"],
+                            output_tokens=usage["output_tokens"],
+                            finish_reason=bedrock_response.get("stopReason", "end_turn"),
+                        )
+                        span.set_attribute("gen_ai.response.model", BEDROCK_MODEL_ID)
 
-                # Check for token_limit_exceeded fault
-                if self._should_inject_fault(fault) and fault.type == "token_limit_exceeded":
+                        tool_use = extract_tool_use(bedrock_response)
+                        if tool_use:
+                            tool_name = tool_use["name"]
+                            tool_args = tool_use["input"]
+                            tool_use_id = tool_use["toolUseId"]
+
+                            if self._should_inject_fault(fault) and fault.type == "wrong_tool":
+                                wrong_tools = {"get_current_weather": "get_forecast", "get_forecast": "get_historical_weather", "get_historical_weather": "get_current_weather"}
+                                tool_name = wrong_tools.get(tool_name, tool_name)
+
+                            tool_result = self.execute_tool(tool_name, tool_args, tool_use_id, fault)
+
+                            # Second Bedrock call with tool result for final answer
+                            bedrock_messages.append(bedrock_response["output"]["message"])
+                            bedrock_messages.append({"role": "user", "content": [{"toolResult": {"toolUseId": tool_use_id, "content": [{"json": tool_result}]}}]})
+                            final_response_obj = converse(_bedrock_client, bedrock_messages, system=system_instructions[0]["content"])
+                            final_response = extract_text(final_response_obj)
+                            usage2 = get_usage(final_response_obj)
+                            self.token_counter.add(usage["input_tokens"] + usage2["input_tokens"], attributes={"gen_ai.token.type": "input", "gen_ai.provider.name": "aws_bedrock", "gen_ai.request.model": BEDROCK_MODEL_ID})
+                            self.token_counter.add(usage["output_tokens"] + usage2["output_tokens"], attributes={"gen_ai.token.type": "output", "gen_ai.provider.name": "aws_bedrock", "gen_ai.request.model": BEDROCK_MODEL_ID})
+                        else:
+                            final_response = extract_text(bedrock_response)
+
+                    except BedrockUnavailableError as e:
+                        span.set_attribute("gen_ai.bedrock.fallback", True)
+                        span.set_attribute("gen_ai.bedrock.fallback.reason", str(e)[:200])
+                        # Fall through to mock path below
+                        llm_response = call_llm(self.model, messages, self.tools)
+                        tool_call = llm_response["choices"][0]["message"].get("tool_calls", [None])[0]
+                        if tool_call:
+                            tool_name = tool_call["function"]["name"]
+                            tool_args = json.loads(tool_call["function"]["arguments"])
+                            tool_result = self.execute_tool(tool_name, tool_args, tool_call["id"], fault)
+                            final_response = f"The weather in {tool_result.get('location', 'unknown')} is {tool_result.get('condition', 'unknown')} with a temperature of {tool_result.get('temperature', 'N/A')}."
+                        else:
+                            final_response = "I couldn't determine what you're asking about."
+                        enrich(finish_reason="stop", input_tokens=llm_response["usage"]["prompt_tokens"], output_tokens=llm_response["usage"]["completion_tokens"])
+                else:
+                    # --- Mock path ---
+                    llm_response = call_llm(self.model, messages, self.tools)
+
+                    if self._should_inject_fault(fault) and fault.type == "token_limit_exceeded":
+                        enrich(response_id=llm_response["id"], finish_reason="length", input_tokens=llm_response["usage"]["prompt_tokens"], output_tokens=1024)
+                        span.set_attribute("gen_ai.response.model", llm_response["model"])
+                        truncated_response = "The weather in the requested location is currently showing temperatures around—"
+                        enrich(output_messages=[{"role": "assistant", "parts": [{"type": "text", "content": truncated_response}], "finish_reason": "length"}])
+                        span.set_status(Status(StatusCode.OK))
+                        return truncated_response
+
                     enrich(
                         response_id=llm_response["id"],
-                        finish_reason="length",
+                        finish_reason=llm_response["choices"][0]["finish_reason"],
                         input_tokens=llm_response["usage"]["prompt_tokens"],
-                        output_tokens=1024,
+                        output_tokens=llm_response["usage"]["completion_tokens"],
                     )
                     span.set_attribute("gen_ai.response.model", llm_response["model"])
-                    truncated_response = "The weather in the requested location is currently showing temperatures around—"
-                    enrich(output_messages=[{"role": "assistant", "parts": [{"type": "text", "content": truncated_response}], "finish_reason": "length"}])
-                    span.set_status(Status(StatusCode.OK))
-                    return truncated_response
 
-                # Set response attributes via enrich()
-                enrich(
-                    response_id=llm_response["id"],
-                    finish_reason=llm_response["choices"][0]["finish_reason"],
-                    input_tokens=llm_response["usage"]["prompt_tokens"],
-                    output_tokens=llm_response["usage"]["completion_tokens"],
-                )
-                span.set_attribute("gen_ai.response.model", llm_response["model"])
+                    self.token_counter.add(llm_response["usage"]["prompt_tokens"], attributes={"gen_ai.operation.name": "invoke_agent", "gen_ai.provider.name": "openai", "gen_ai.request.model": self.model, "gen_ai.response.model": llm_response["model"], "gen_ai.token.type": "input", "server.address": "api.openai.com"})
+                    self.token_counter.add(llm_response["usage"]["completion_tokens"], attributes={"gen_ai.operation.name": "invoke_agent", "gen_ai.provider.name": "openai", "gen_ai.request.model": self.model, "gen_ai.response.model": llm_response["model"], "gen_ai.token.type": "output", "server.address": "api.openai.com"})
 
-                # Record token usage metrics
-                self.token_counter.add(
-                    llm_response["usage"]["prompt_tokens"],
-                    attributes={
-                        "gen_ai.operation.name": "invoke_agent",
-                        "gen_ai.provider.name": "openai",
-                        "gen_ai.request.model": self.model,
-                        "gen_ai.response.model": llm_response["model"],
-                        "gen_ai.token.type": "input",
-                        "server.address": "api.openai.com"
-                    }
-                )
-                self.token_counter.add(
-                    llm_response["usage"]["completion_tokens"],
-                    attributes={
-                        "gen_ai.operation.name": "invoke_agent",
-                        "gen_ai.provider.name": "openai",
-                        "gen_ai.request.model": self.model,
-                        "gen_ai.response.model": llm_response["model"],
-                        "gen_ai.token.type": "output",
-                        "server.address": "api.openai.com"
-                    }
-                )
+                    tool_call = llm_response["choices"][0]["message"].get("tool_calls", [None])[0]
+                    tool_call_id = tool_call["id"] if tool_call else None
 
-                # Execute tool if requested
-                tool_call = llm_response["choices"][0]["message"].get("tool_calls", [None])[0]
-                tool_call_id = tool_call["id"] if tool_call else None
+                    if tool_call:
+                        tool_name = tool_call["function"]["name"]
+                        tool_args = json.loads(tool_call["function"]["arguments"])
 
-                if tool_call:
-                    tool_name = tool_call["function"]["name"]
-                    tool_args = json.loads(tool_call["function"]["arguments"])
+                        if self._should_inject_fault(fault) and fault.type == "wrong_tool":
+                            wrong_tools = {"get_current_weather": "get_forecast", "get_forecast": "get_historical_weather", "get_historical_weather": "get_current_weather"}
+                            tool_name = wrong_tools.get(tool_name, tool_name)
+                            if tool_name == "get_historical_weather":
+                                tool_args["date"] = "2026-01-25"
 
-                    # wrong_tool fault: swap the tool being called
-                    if self._should_inject_fault(fault) and fault.type == "wrong_tool":
-                        wrong_tools = {"get_current_weather": "get_forecast", "get_forecast": "get_historical_weather", "get_historical_weather": "get_current_weather"}
-                        tool_name = wrong_tools.get(tool_name, tool_name)
-                        if tool_name == "get_historical_weather":
-                            tool_args["date"] = "2026-01-25"
+                        tool_result = self.execute_tool(tool_name, tool_args, tool_call_id, fault)
 
-                    tool_result = self.execute_tool(tool_name, tool_args, tool_call_id, fault)
-
-                    # Generate final response based on tool result
-                    if "temperature" in tool_result:
-                        final_response = f"The weather in {tool_result['location']} is {tool_result['condition']} with a temperature of {tool_result['temperature']}."
-                    elif "forecast" in tool_result:
-                        days = tool_result["forecast"]
-                        final_response = f"Forecast for {tool_result['location']}: Day 1: {days[0]['condition']}, high {days[0]['high']}."
-                    elif "date" in tool_result:
-                        final_response = f"On {tool_result['date']} in {tool_result['location']}: {tool_result['condition']}, high {tool_result['high']}."
+                        if "temperature" in tool_result:
+                            final_response = f"The weather in {tool_result['location']} is {tool_result['condition']} with a temperature of {tool_result['temperature']}."
+                        elif "forecast" in tool_result:
+                            days = tool_result["forecast"]
+                            final_response = f"Forecast for {tool_result['location']}: Day 1: {days[0]['condition']}, high {days[0]['high']}."
+                        elif "date" in tool_result:
+                            final_response = f"On {tool_result['date']} in {tool_result['location']}: {tool_result['condition']}, high {tool_result['high']}."
+                        else:
+                            final_response = f"Weather data for {tool_result.get('location', 'unknown')}: {tool_result}"
                     else:
-                        final_response = f"Weather data for {tool_result.get('location', 'unknown')}: {tool_result}"
-                else:
-                    final_response = "I couldn't determine what you're asking about."
+                        final_response = "I couldn't determine what you're asking about."
 
                 # Record output messages via enrich()
                 enrich(output_messages=[
@@ -530,6 +583,10 @@ class WeatherAgent:
             span.set_attribute("network.transport", "tcp")
             span.set_attribute("network.protocol.name", "http")
 
+            enrich(
+                input_messages=[{"role": "tool_call", "parts": [{"type": "text", "content": json.dumps(arguments)}]}],
+            )
+
             headers = {"mcp-session-id": session_id}
             inject(headers)
             payload = {
@@ -540,7 +597,12 @@ class WeatherAgent:
             data = resp.json()
             if "error" in data:
                 raise ToolExecutionError(data["error"].get("message", "MCP tool error"))
-            return data.get("result", {})
+            tool_result = data.get("result", {})
+
+            enrich(
+                output_messages=[{"role": "tool_result", "parts": [{"type": "text", "content": json.dumps(tool_result)}]}],
+            )
+            return tool_result
 
     def execute_tool(self, tool_name: str, arguments: Dict[str, Any], tool_call_id: str = None, fault: Optional[FaultConfig] = None) -> Dict[str, Any]:
         """
@@ -559,6 +621,10 @@ class WeatherAgent:
                 if tool_def:
                     span.set_attribute("gen_ai.tool.description", tool_def["function"]["description"])
                 span.set_attribute("gen_ai.tool.call.arguments", json.dumps(arguments))
+
+                enrich(
+                    input_messages=[{"role": "tool_call", "parts": [{"type": "text", "content": json.dumps(arguments)}]}],
+                )
 
                 # Check for fault injection
                 if self._should_inject_fault(fault) and fault.type in ("tool_timeout", "tool_error", "high_latency"):
@@ -593,6 +659,9 @@ class WeatherAgent:
                     raise ValueError(f"Unknown tool: {tool_name}")
 
                 span.set_attribute("gen_ai.tool.call.result", json.dumps(result))
+                enrich(
+                    output_messages=[{"role": "tool_result", "parts": [{"type": "text", "content": json.dumps(result)}]}],
+                )
                 span.set_status(Status(StatusCode.OK))
                 return result
 


### PR DESCRIPTION
## Summary

Transforms the multi-agent travel planner from a fully mocked demo into a realistic observability showcase with real APIs, real LLM reasoning, and a live control panel.

### Real Free APIs (no keys required)
- **Weather**: Open-Meteo API (geocoding + forecast) — real temperature, conditions, wind
- **Attractions**: Wikipedia API (page summary + search) — real landmarks and POIs
- **Currency**: Frankfurter API (live ECB rates) — real-time exchange rates
- **Flights**: realistic simulated data (no free flight API exists)
- All API calls gracefully fall back to mock data when unreachable

### Amazon Bedrock LLM Integration
- Real LLM calls via Bedrock Converse API (default: ~~Claude Opus 4.8~~ Haiku)
- **Weather Agent**: full agentic tool_use loop — Bedrock selects tools, executes, responds
- **Orchestrator**: Bedrock plans the trip and synthesizes a natural-language recommendation
- **Events Agent**: Bedrock reasons about what attractions to look for
- Live toggle in the control panel — no restart needed
- Graceful fallback to mock if no AWS credentials

### Travel Agent Control Panel (port 8085)
- One-click scenario presets: All Clean, Default, Chaos, Latency Spike, Cascading Failure, Deep Traces
- Each preset shows what to look for in the observability dashboards
- Real LLM toggle (Bedrock on/off)
- Read-only bars for preset visualization, editable sliders in Custom mode
- State persists across container restarts
- Canary polls panel every cycle for live config updates
<img width="1680" height="665" alt="Screenshot 2026-06-03 at 4 45 13 PM" src="https://github.com/user-attachments/assets/0ef95c51-6d3d-4ec0-817a-60cd3f5218c6" />




### Trace Improvements
- 4 tools produce deeper, more varied trace waterfalls (40-100+ spans)
- `gen_ai.input.messages` / `gen_ai.output.messages` on tool execution spans
- Real token counts from Bedrock (`gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`)
- `gen_ai.provider.name=aws_bedrock` distinguishes real vs mock traces
- Comprehensive README documenting the full setup

## Test plan

- [ ] `docker compose up -d` with no AWS creds — mock mode works, control panel loads at :8085
- [ ] `curl -X POST http://localhost:8003/plan -d '{"destination":"Tokyo","origin":"Portland"}'` — returns real weather + Wikipedia attractions + flights + currency
- [ ] Toggle "Real LLM" ON with valid AWS creds — recommendation becomes LLM-generated
- [ ] Toggle "Real LLM" OFF — immediately reverts to template responses
- [ ] Click "Chaos" preset — canary injects faults every 10s
- [ ] Click "All Clean" — only healthy traces
- [ ] Restart fault-panel container — state persists
- [ ] Traces in OpenSearch show `gen_ai.provider.name=aws_bedrock` with real token counts
- [ ] Without AWS creds + Real LLM ON — fallback to mock, `gen_ai.bedrock.fallback=true` in spans