### PR TITLE
ci: pin upload-pages-artifact to v4.0.0 to fix blocked docs deploy

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -61,7 +61,7 @@ jobs:
           cp -r starlight-docs/dist/* dist/docs/
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
           path: ./docs/dist
 


### PR DESCRIPTION
## Description

The "Deploy Docs to GitHub Pages" workflow fails at job setup, so merged docs changes do not publish. `actions/upload-pages-artifact@v3` transitively calls `actions/upload-artifact@v4` as a floating tag inside its own `action.yml`, and the repo's full-SHA pinning policy (#260) rejects it before any build step runs:

```
The action actions/upload-artifact@v4 is not allowed in
opensearch-project/observability-stack because all actions
must be pinned to a full-length commit SHA.
```

This bumps `upload-pages-artifact` to v4.0.0, pinned to its full commit SHA. v4.0.0 pins its internal `upload-artifact` to a SHA (`v4.6.2`), satisfying the policy. The other actions in this workflow (`configure-pages`, `deploy-pages`) were checked and have no unpinned transitive `uses:`.

## Issues Resolved

Closes #300

## Check List

- [x] All tests pass (single-line workflow change; YAML validated)
- [x] New functionality has been documented (n/a)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
