### PR TITLE
fix(cli): stop managed EC2 demo starting zero containers (#298)

### DIFF
--- a/.env
+++ b/.env
@@ -11,10 +11,10 @@ INCLUDE_COMPOSE_EXAMPLES=docker-compose.examples.yml
 INCLUDE_COMPOSE_LOCAL_OPENSEARCH=docker-compose.local-opensearch.yml
 INCLUDE_COMPOSE_LOCAL_OPENSEARCH_DASHBOARDS=docker-compose.local-opensearch-dashboards.yml
 
-# Activate services that require a local backend (eval canary, otel-demo monitors).
-# These hardcode http://prometheus:9090 / https://opensearch:9200 and have no
-# managed-backend path. Managed-mode deploys leave COMPOSE_PROFILES unset, which
-# prunes those services and their depends_on edges so the project validates.
+# Activates services that require a local backend (eval canary, otel-demo
+# monitors). These hardcode http://prometheus:9090 / https://opensearch:9200
+# with no managed-backend path. Managed-mode deploys leave COMPOSE_PROFILES
+# unset to prune them.
 COMPOSE_PROFILES=local-backends
 
 # TODO: Change to opensearchproject after 3.7.0 official release

--- a/.env
+++ b/.env
@@ -11,6 +11,12 @@ INCLUDE_COMPOSE_EXAMPLES=docker-compose.examples.yml
 INCLUDE_COMPOSE_LOCAL_OPENSEARCH=docker-compose.local-opensearch.yml
 INCLUDE_COMPOSE_LOCAL_OPENSEARCH_DASHBOARDS=docker-compose.local-opensearch-dashboards.yml
 
+# Activate services that require a local backend (eval canary, otel-demo monitors).
+# These hardcode http://prometheus:9090 / https://opensearch:9200 and have no
+# managed-backend path. Managed-mode deploys leave COMPOSE_PROFILES unset, which
+# prunes those services and their depends_on edges so the project validates.
+COMPOSE_PROFILES=local-backends
+
 # TODO: Change to opensearchproject after 3.7.0 official release
 OPENSEARCH_DOCKER_REPO=opensearchstaging
 

--- a/aws/cli-installer/package-lock.json
+++ b/aws/cli-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opensearch-project/observability-stack",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opensearch-project/observability-stack",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-js": "^5.2.0",

--- a/aws/cli-installer/package.json
+++ b/aws/cli-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensearch-project/observability-stack",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "CLI for the Observability Stack",
   "type": "module",
   "bin": "./bin/cli-installer.mjs",

--- a/aws/cli-installer/src/ec2-demo.mjs
+++ b/aws/cli-installer/src/ec2-demo.mjs
@@ -201,10 +201,9 @@ services:
     logging: *logging
 MANAGEDEOF
 
-# Managed mode has no local opensearch/prometheus, so prune the services that
-# require them by clearing COMPOSE_PROFILES (overrides the local-backends value
-# committed in .env). Without this, compose rejects the project on the
-# unresolved depends_on edges and starts zero containers.
+# Managed mode has no local opensearch/prometheus. Clear COMPOSE_PROFILES
+# (overriding the local-backends value committed in .env) to prune the services
+# that require those backends, leaving the project with resolvable depends_on.
 export COMPOSE_PROFILES=
 
 # Kafka's healthcheck can exceed compose's dependency grace window on first boot,

--- a/aws/cli-installer/src/ec2-demo.mjs
+++ b/aws/cli-installer/src/ec2-demo.mjs
@@ -136,9 +136,8 @@ curl -SL "https://github.com/docker/buildx/releases/download/\${BUILDX_VERSION}/
   -o /usr/local/lib/docker/cli-plugins/docker-buildx
 chmod +x /usr/local/lib/docker/cli-plugins/docker-buildx
 
-# Clone the stack at the revision this CLI release was built against, so the
-# stack can't drift out from under a pinned CLI. Fall back to the default branch
-# if the ref is absent (e.g. an untagged dev build).
+# Clone the stack at the pinned ref (see STACK_REF). Fall back to the default
+# branch if the ref is absent (e.g. an untagged dev build).
 OBS_STACK_REF="${STACK_REF}"
 if ! git clone --depth 1 --branch "\$OBS_STACK_REF" https://github.com/opensearch-project/observability-stack.git /opt/obs-stack; then
   echo "WARNING: ref \$OBS_STACK_REF not found, falling back to default branch"
@@ -203,7 +202,7 @@ MANAGEDEOF
 
 # Managed mode has no local opensearch/prometheus. Clear COMPOSE_PROFILES
 # (overriding the local-backends value committed in .env) to prune the services
-# that require those backends, leaving the project with resolvable depends_on.
+# that require those backends.
 export COMPOSE_PROFILES=
 
 # Kafka's healthcheck can exceed compose's dependency grace window on first boot,

--- a/aws/cli-installer/src/ec2-demo.mjs
+++ b/aws/cli-installer/src/ec2-demo.mjs
@@ -19,10 +19,19 @@ import {
 import {
   SSMClient, GetParameterCommand,
 } from '@aws-sdk/client-ssm';
+import { createRequire } from 'node:module';
 import { printStep, printSuccess, printWarning, printInfo, createSpinner } from './ui.mjs';
+
+const require = createRequire(import.meta.url);
+const { version: PKG_VERSION } = require('../package.json');
 
 const TAG_KEY = 'observability-stack:pipeline-name';
 const INSTANCE_TYPE = 't3.xlarge';
+
+// The stack revision the EC2 instance clones. Defaults to the git tag matching
+// this CLI release so a pinned CLI deploys a pinned stack (no drift from main
+// HEAD at boot time). Override with OBS_STACK_REF for development.
+const STACK_REF = process.env.OBS_STACK_REF || `cli-installer-v${PKG_VERSION}`;
 
 function tags(pipelineName, extra = {}) {
   return [
@@ -127,7 +136,14 @@ curl -SL "https://github.com/docker/buildx/releases/download/\${BUILDX_VERSION}/
   -o /usr/local/lib/docker/cli-plugins/docker-buildx
 chmod +x /usr/local/lib/docker/cli-plugins/docker-buildx
 
-git clone --depth 1 https://github.com/opensearch-project/observability-stack.git /opt/obs-stack
+# Clone the stack at the revision this CLI release was built against, so the
+# stack can't drift out from under a pinned CLI. Fall back to the default branch
+# if the ref is absent (e.g. an untagged dev build).
+OBS_STACK_REF="${STACK_REF}"
+if ! git clone --depth 1 --branch "\$OBS_STACK_REF" https://github.com/opensearch-project/observability-stack.git /opt/obs-stack; then
+  echo "WARNING: ref \$OBS_STACK_REF not found, falling back to default branch"
+  git clone --depth 1 https://github.com/opensearch-project/observability-stack.git /opt/obs-stack
+fi
 cd /opt/obs-stack
 
 cat > docker-compose/otel-collector/config.yaml << 'COLLECTOREOF'
@@ -184,6 +200,12 @@ services:
           memory: 500M
     logging: *logging
 MANAGEDEOF
+
+# Managed mode has no local opensearch/prometheus, so prune the services that
+# require them by clearing COMPOSE_PROFILES (overrides the local-backends value
+# committed in .env). Without this, compose rejects the project on the
+# unresolved depends_on edges and starts zero containers.
+export COMPOSE_PROFILES=
 
 # Kafka's healthcheck can exceed compose's dependency grace window on first boot,
 # leaving kafka-dependent services in 'Created' state. Retry once — second pass

--- a/aws/cli-installer/test/unit.test.mjs
+++ b/aws/cli-installer/test/unit.test.mjs
@@ -159,6 +159,17 @@ describe('EC2 demo buildUserData', () => {
     assert.ok(decoded.includes('docker-compose'));
     assert.ok(decoded.includes('docker-buildx'));
   });
+
+  it('pins the stack clone to a ref instead of tracking main HEAD', () => {
+    const decoded = Buffer.from(_buildUserData(cfg), 'base64').toString();
+    assert.ok(decoded.includes('--branch "$OBS_STACK_REF"'));
+    assert.ok(decoded.includes('cli-installer-v'));
+  });
+
+  it('clears COMPOSE_PROFILES so local-backend services are pruned in managed mode', () => {
+    const decoded = Buffer.from(_buildUserData(cfg), 'base64').toString();
+    assert.ok(decoded.includes('export COMPOSE_PROFILES='));
+  });
 });
 
 // ── renderPipeline tests ─────────────────────────────────────────────────────

--- a/aws/cli-installer/test/unit.test.mjs
+++ b/aws/cli-installer/test/unit.test.mjs
@@ -173,12 +173,9 @@ describe('EC2 demo buildUserData', () => {
 });
 
 // ── managed-mode compose project resolution ──────────────────────────────────
-// Regression guard for #298: the docker-compose.managed.yml that user-data
-// writes must validate as a project. It includes examples + otel-demo but
-// defines no local opensearch/prometheus, so any service in those files that
-// depends_on a local backend must be pruned by the empty COMPOSE_PROFILES that
-// managed mode runs with. Without that, `docker compose` rejects the whole
-// project and the instance starts zero containers.
+// Regression guard for #298: the generated docker-compose.managed.yml must
+// resolve as a valid project with COMPOSE_PROFILES empty, with every
+// local-backend service pruned (managed mode defines no opensearch/prometheus).
 
 import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';

--- a/aws/cli-installer/test/unit.test.mjs
+++ b/aws/cli-installer/test/unit.test.mjs
@@ -172,6 +172,71 @@ describe('EC2 demo buildUserData', () => {
   });
 });
 
+// ── managed-mode compose project resolution ──────────────────────────────────
+// Regression guard for #298: the docker-compose.managed.yml that user-data
+// writes must validate as a project. It includes examples + otel-demo but
+// defines no local opensearch/prometheus, so any service in those files that
+// depends_on a local backend must be pruned by the empty COMPOSE_PROFILES that
+// managed mode runs with. Without that, `docker compose` rejects the whole
+// project and the instance starts zero containers.
+
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { writeFileSync, rmSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+
+function dockerComposeAvailable() {
+  try {
+    execFileSync('docker', ['compose', 'version'], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Extract the docker-compose.managed.yml heredoc body from generated user-data.
+function extractManagedCompose(userDataB64) {
+  const decoded = Buffer.from(userDataB64, 'base64').toString();
+  const m = decoded.match(/docker-compose\.managed\.yml << .MANAGEDEOF.\n([\s\S]*?)\nMANAGEDEOF/);
+  if (!m) throw new Error('managed compose heredoc not found in user-data');
+  return m[1];
+}
+
+describe('EC2 demo managed compose project', { skip: !dockerComposeAvailable() }, () => {
+  const cfg = {
+    pipelineName: 'test-pipeline',
+    region: 'us-west-2',
+    ingestEndpoints: ['test-pipeline-abc123.us-west-2.osis.amazonaws.com'],
+  };
+  // Repo root holds the included compose files; managed.yml's relative
+  // include: paths resolve against the file's own directory.
+  const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+  const managedPath = join(repoRoot, 'docker-compose.managed.yml');
+
+  function configServices(profiles) {
+    return execFileSync(
+      'docker', ['compose', '-f', managedPath, 'config', '--services'],
+      { cwd: repoRoot, env: { ...process.env, COMPOSE_PROFILES: profiles }, encoding: 'utf8' },
+    ).split('\n').filter(Boolean);
+  }
+
+  it('validates and prunes local-backend services when COMPOSE_PROFILES is empty', () => {
+    writeFileSync(managedPath, extractManagedCompose(_buildUserData(cfg)));
+    try {
+      const services = configServices('');
+      assert.ok(services.length > 0, 'expected the managed project to resolve to a non-empty service list');
+      assert.ok(!services.includes('example-agent-eval-canary'),
+        'eval canary should be pruned in managed mode (no local opensearch)');
+      assert.ok(!services.includes('otel-demo-alerting-rules-monitors-init'),
+        'otel-demo monitors-init should be pruned in managed mode (no local prometheus/opensearch)');
+      assert.ok(services.includes('otel-collector'),
+        'otel-collector should always be present');
+    } finally {
+      rmSync(managedPath, { force: true });
+    }
+  });
+});
+
 // ── renderPipeline tests ─────────────────────────────────────────────────────
 
 import { renderPipeline } from '../src/render.mjs';

--- a/docker-compose.examples.yml
+++ b/docker-compose.examples.yml
@@ -177,8 +177,12 @@ services:
           memory: 128M
     logging: *logging
 
-  # Agent Eval Canary: periodically scores un-evaluated agent traces
+  # Agent Eval Canary: periodically scores un-evaluated agent traces.
+  # Hardcodes a local basic-auth OpenSearch backend (no managed-backend path),
+  # so it is gated behind the "local-backends" profile. Managed mode runs with
+  # COMPOSE_PROFILES unset, which prunes this service and its depends_on edges.
   example-agent-eval-canary:
+    profiles: ["local-backends"]
     build:
       context: ./docker-compose/agent-eval-canary
       dockerfile: Dockerfile

--- a/docker-compose.examples.yml
+++ b/docker-compose.examples.yml
@@ -178,9 +178,8 @@ services:
     logging: *logging
 
   # Agent Eval Canary: periodically scores un-evaluated agent traces.
-  # Hardcodes a local basic-auth OpenSearch backend (no managed-backend path),
-  # so it is gated behind the "local-backends" profile. Managed mode runs with
-  # COMPOSE_PROFILES unset, which prunes this service and its depends_on edges.
+  # Requires a local OpenSearch backend; gated behind the local-backends
+  # profile (see COMPOSE_PROFILES in .env).
   example-agent-eval-canary:
     profiles: ["local-backends"]
     build:

--- a/docker-compose.otel-demo.yml
+++ b/docker-compose.otel-demo.yml
@@ -774,10 +774,8 @@ services:
   # failure. Named separately from the base container rather than overlaying it
   # because Docker Compose >= v2.38 rejects service-name overlays on
   # `include:`-imported resources. Both containers hit idempotent upsert APIs.
-  # Targets local Cortex (http://prometheus:9090) and local basic-auth OpenSearch
-  # (https://opensearch:9200); neither has a managed-backend path, so this is
-  # gated behind the "local-backends" profile. Managed mode runs with
-  # COMPOSE_PROFILES unset, which prunes this service and its depends_on edges.
+  # Requires local Cortex (prometheus) and OpenSearch backends; gated behind
+  # the local-backends profile (see COMPOSE_PROFILES in .env).
   otel-demo-alerting-rules-monitors-init:
     profiles: ["local-backends"]
     image: python:3.11-alpine

--- a/docker-compose.otel-demo.yml
+++ b/docker-compose.otel-demo.yml
@@ -774,7 +774,12 @@ services:
   # failure. Named separately from the base container rather than overlaying it
   # because Docker Compose >= v2.38 rejects service-name overlays on
   # `include:`-imported resources. Both containers hit idempotent upsert APIs.
+  # Targets local Cortex (http://prometheus:9090) and local basic-auth OpenSearch
+  # (https://opensearch:9200); neither has a managed-backend path, so this is
+  # gated behind the "local-backends" profile. Managed mode runs with
+  # COMPOSE_PROFILES unset, which prunes this service and its depends_on edges.
   otel-demo-alerting-rules-monitors-init:
+    profiles: ["local-backends"]
     image: python:3.11-alpine
     container_name: otel-demo-alerting-rules-monitors-init
     command:


### PR DESCRIPTION
## What

Fixes #298. A managed-mode `npx @opensearch-project/observability-stack` deploy provisioned AWS resources fine but started **zero containers**. `docker compose up` aborted at project validation with `service "example-agent-eval-canary" depends on undefined service "opensearch": invalid compose project`, so no telemetry ever reached OpenSearch.

## Root cause

Two independent design choices combined into a version-skew bug.

1. **Managed mode defines no local backend.** The generated `docker-compose.managed.yml` includes `docker-compose.examples.yml` plus `docker-compose.otel-demo.yml` but defines only `otel-collector`. Telemetry ships to the remote OSIS pipeline via SigV4, so there is no local `opensearch`/`prometheus`.
2. **The EC2 user-data cloned the stack at `main` HEAD with no pinned ref.** A "pinned" CLI release still deployed whatever `main` looked like the day the instance booted.

Two services in the included files (`example-agent-eval-canary`, `otel-demo-alerting-rules-monitors-init`) `depends_on` a local backend. They were added to `main` after the CLI was tagged (`cli-installer-v0.1.1`, 2026-04-09), so the same CLI binary that worked in April started failing once those services landed. When a `depends_on` target isn't defined, Compose rejects the whole project.

Both services hardcode a local backend with no managed path (`https://opensearch:9200` basic-auth; `http://prometheus:9090` Cortex), so they don't belong in managed mode regardless.

## Fix

- **Gate both services behind a `local-backends` compose profile.** Compose prunes a profiled-out service and its `depends_on` edges, so managed mode validates clean while the local path is unchanged.
- **Default `COMPOSE_PROFILES=local-backends` in committed `.env`** so a raw `docker compose up` keeps these services on. Managed user-data exports an empty `COMPOSE_PROFILES` to prune them.
- **Pin the EC2 stack clone** to `cli-installer-v<version>` (override via `OBS_STACK_REF`), falling back to the default branch if the ref is absent.
- **Bump the CLI to `0.1.2`** so the pin resolves to a tag that contains the gate (see release dependency below).

## Release dependency (important)

The profile gate is the actual fix; the clone pin is hardening. But the two interact through the CLI version, and the ordering matters:

- The published CLI pins the clone to `cli-installer-v${package.json version}`.
- At `0.1.1`, that tag predates both the offending services and this gate. So a `0.1.1` deploy avoids the crash only by cloning an April-vintage stack, the gate never runs, and users silently get a months-old stack.
- The gate only executes once the CLI clones a tag built from `main` with this PR.

This PR bumps `package.json` to `0.1.2` so the path is: merge, then a maintainer pushes the `cli-installer-v0.1.2` tag (gated behind the `release-approval` environment), which publishes to npm. A `0.1.2` deploy then clones `cli-installer-v0.1.2`, which has the gate. Until that tag is cut, the fix is not live for `npx` users.

### Tradeoff worth noting

Pinning the clone means stack fixes won't reach already-pinned CLI deploys until a new CLI tag ships. That's correctness over freshness, the right call for a reproducible demo installer, but worth stating.

## Validation

- Managed mode (`COMPOSE_PROFILES=` empty): `docker compose -f docker-compose.managed.yml config` resolves **30 services**, exit 0, both offenders pruned.
- Local mode via root `docker-compose.yml` with profile active: **40 services**, both offenders and both backends present.
- Local mode with profile unset: offenders pruned (confirms the gate).
- Reproduced the original failure and the fix on a real `docker compose` run: un-gated → `invalid compose project` (zero containers); gated with empty profiles → `otel-collector` starts (`Everything is ready`, GRPC 4317 / HTTP 4318).
- CLI unit tests: **29/29 pass**, including a new managed-mode test that runs `docker compose config` on the generated `docker-compose.managed.yml` and asserts the offenders are pruned.

### Why CI didn't catch the original bug

Both e2e jobs exercise the **local** path only. `e2e-compose` runs root-compose where `opensearch`/`prometheus` exist, so the `depends_on` edges resolve. `e2e-install` runs `install.sh` with the local target and declines examples/otel-demo, so the offending files aren't even included, and the managed branch (`ec2-demo.mjs`) is never entered. Nothing validated the generated managed compose project. The new CLI test closes that gap at the `config` level.

A full managed `npx` deploy against live AWS/OSIS has **not** been run for this branch.

## Follow-up (separate PR, not blocking this one)

OSIS data-plane warm-up: control-plane `Status=ACTIVE` does not mean the ingest endpoint accepts traffic. For several minutes after, the collector logs a wall of `failed to make an HTTP request: ...: EOF` on every export and OpenSearch stays empty, so a fresh deploy reads as broken even though it self-heals. Proposed fix: after `ACTIVE`, poll the ingest endpoint until it returns any HTTP response (401 to an unsigned probe means the data plane is up), time-boxed, warn and continue. Tracked separately.

## TODO before marking ready for review

- [ ] After merge, cut the `cli-installer-v0.1.2` tag so the published CLI clones a stack containing the gate. Without it, the fix is committed but not live for `npx` users.
