### PR TITLE
chore: use official opensearchproject images now that 3.7.0 has shipped

### DIFF
--- a/.env
+++ b/.env
@@ -17,8 +17,7 @@ INCLUDE_COMPOSE_LOCAL_OPENSEARCH_DASHBOARDS=docker-compose.local-opensearch-dash
 # unset to prune them.
 COMPOSE_PROFILES=local-backends
 
-# TODO: Change to opensearchproject after 3.7.0 official release
-OPENSEARCH_DOCKER_REPO=opensearchstaging
+OPENSEARCH_DOCKER_REPO=opensearchproject
 
 
 # OpenSearch Configuration

--- a/charts/observability-stack/values.yaml
+++ b/charts/observability-stack/values.yaml
@@ -12,9 +12,8 @@ opensearch:
   enabled: true
   singleNode: false
   replicas: 3
-  # TODO: Change to opensearchproject/opensearch after 3.7.0 official release
   image:
-    repository: "opensearchstaging/opensearch"
+    repository: "opensearchproject/opensearch"
     tag: "3.7.0"
   resources:
     requests:
@@ -77,9 +76,8 @@ opensearch:
 opensearch-dashboards:
   enabled: true
   replicaCount: 3
-  # TODO: Change to opensearchproject/opensearch-dashboards after 3.7.0 official release
   image:
-    repository: "opensearchstaging/opensearch-dashboards"
+    repository: "opensearchproject/opensearch-dashboards"
     tag: "3.7.0"
   resources:
     requests:

--- a/install.sh
+++ b/install.sh
@@ -849,8 +849,8 @@ run_simulated_installer() {
 
     # Demo image list
     local images=(
-        "opensearchstaging/opensearch:3.7.0"
-        "opensearchstaging/opensearch-dashboards:3.7.0"
+        "opensearchproject/opensearch:3.7.0"
+        "opensearchproject/opensearch-dashboards:3.7.0"
         "otel/opentelemetry-collector-contrib:0.143.0"
         "opensearchproject/data-prepper:2.13.0"
         "prom/prometheus:v3.8.1"


### PR DESCRIPTION
## What

Swaps all `opensearchstaging/*` OpenSearch and OpenSearch Dashboards image references to `opensearchproject/*`. Four references across three files, plus removal of three now-obsolete `TODO: change after 3.7.0 official release` comments.

## Why

3.7.0 was pinned to the `opensearchstaging` repo while the release was in flight. Official `opensearchproject/opensearch:3.7.0` and `opensearchproject/opensearch-dashboards:3.7.0` are now published, so the staging pin can be retired. The staging tags are mutable, which made it hard to reason about exactly which build a user was running. Moving to the official repo removes that ambiguity.

## Changes

- `.env`: `OPENSEARCH_DOCKER_REPO` → `opensearchproject` (drives both compose OpenSearch and OSD via `${OPENSEARCH_DOCKER_REPO}`)
- `charts/observability-stack/values.yaml`: `opensearch.image.repository` and `opensearch-dashboards.image.repository` → `opensearchproject/*`
- `install.sh`: demo image list → `opensearchproject/opensearch:3.7.0`, `opensearchproject/opensearch-dashboards:3.7.0`

## Validation

- Official and staging 3.7.0 images are byte-identical, so this is a pure repo swap with no content change:
  - `opensearch@sha256:123e6591…128f`
  - `opensearch-dashboards@sha256:ad707f8c…0151d`
- `docker compose config` resolves both images to `opensearchproject/*`.
- `helm lint charts/observability-stack` passes (0 failures).
- Fresh `docker compose down -v && docker compose pull && docker compose up -d`: all containers healthy. Workspace, `local_cluster` data-source, and the `ObservabilityStack_Prometheus` data-connection all seed correctly (`ACTIVE`, associated to the workspace, visible in the workspace-scoped find that backs the Direct query connections tab).
- `git grep opensearchstaging` returns nothing.
