### PR TITLE
fix(cli): report package version from --version instead of hardcoded 1.0.0

### DIFF
--- a/aws/cli-installer/src/cli.mjs
+++ b/aws/cli-installer/src/cli.mjs
@@ -1,5 +1,9 @@
 import { Command } from 'commander';
+import { createRequire } from 'node:module';
 import { DEFAULTS } from './config.mjs';
+
+const require = createRequire(import.meta.url);
+const { version: PKG_VERSION } = require('../package.json');
 
 /**
  * Parse CLI arguments into a config object.
@@ -18,7 +22,7 @@ export function parseCli(argv) {
       'Create and manage your observability stack on AWS:\n' +
       'OpenSearch, Prometheus, IAM roles, and ingestion pipelines.'
     )
-    .version('1.0.0');
+    .version(PKG_VERSION);
 
   // Mode
   program


### PR DESCRIPTION
## What

`--version` on the AWS CLI installer reported `1.0.0` regardless of the published package version. Against `@opensearch-project/observability-stack@0.2.0-beta.1` it printed `1.0.0`.

## Root cause

`src/cli.mjs` wired commander's `.version()` to a literal `'1.0.0'` that predated the current version scheme. The deploy path already reads the real version from `package.json` (`ec2-demo.mjs` uses it for EC2 tag matching and the version-locked `STACK_REF`), but the user-facing `--version` flag was never updated to match.

## Fix

Read the version from `package.json` via `createRequire`, matching the existing pattern in `ec2-demo.mjs`. `--version` now reports the actual package version.

## Validation

- `node bin/cli-installer.mjs --version` → `0.2.0-beta.1` (was `1.0.0`)
- `npm test` → 29 passed
