### PR TITLE
chore(release): bump CLI to 0.2.0 for GA

### DIFF
--- a/aws/cli-installer/package.json
+++ b/aws/cli-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensearch-project/observability-stack",
-  "version": "0.2.0-beta.1",
+  "version": "0.2.0",
   "description": "CLI for the Observability Stack",
   "type": "module",
   "bin": "./bin/cli-installer.mjs",


### PR DESCRIPTION
## What

Bump `aws/cli-installer/package.json` from `0.2.0-beta.1` to `0.2.0`. On merge and tag, the CLI publishes to the npm `latest` dist-tag. 

### Note for reviewers
Tagging `v0.2.0` is a separate post-merge step (per `RELEASING.md`); this PR only bumps the version so the tag, CLI version, and release agree. The tag is requested via a `.github` repo-management issue, since maintainers can't push release tags directly (opensearch-project/.github#531). Previous example: opensearch-project/.github#575 (the `v0.2.0-beta.1` request).

## Validation

Claude Opus 4.8 (Claude Code) ran a full managed deploy of the `0.2.0-beta.1` artifact (`npx @opensearch-project/observability-stack@beta --quick --region us-east-2`) and queried the backends directly. All resources provisioned: OpenSearch domain, OSIS pipeline `ACTIVE`, APS workspace `ACTIVE`, EC2 demo, dashboards, index patterns.

Data from the bundled OpenTelemetry demo, confirmed by API query (not just deploy exit code):

- Traces: 23,504 spans across 20 services (frontend, cart, checkout, product-catalog, payment, plus the gen-AI agents travel-planner, weather-agent, events-agent, mcp-server). 1,409 carry gen-AI semantic conventions: `execute_tool` (703), `invoke_agent` (482), `chat` (224), with model attribution across claude-opus-4.5, nova-premier, gemini-3-flash, gpt-4.1-mini, o4-mini, and others.
- Logs: 5,759 docs in `logs-otel-v1`.
- Metrics: 387 metric names in APS, including `app_*`, `http_server_request_duration_seconds_count` (7 series), and gen-AI metrics (`gen_ai_client_operation_duration_seconds_*`, `gen_ai_client_token_usage_token_total`).
- Service map: 822 edge docs.

Counts are a point-in-time snapshot while the load-generator drove traffic. Full query output below.

<details>
<summary><b>Raw query evidence</b> (direct API output backing the numbers above; Claude Opus 4.8 via Claude Code)</summary>

Point-in-time snapshot; counts climb while the load-generator drives traffic. `total spans: 10000` in the aggregation is Elasticsearch's default `track_total_hits` cap — `_cat/indices` shows the true count.

**OpenSearch domain** (`search-obs-beta-test…us-east-2.es.amazonaws.com`)

```
### 1. Telemetry indices (_cat/indices)
$ curl -u admin:*** "$OS/_cat/indices?v&h=index,docs.count,store.size&s=index"
index                             docs.count store.size
logs-otel-v1-000001                     5759        6mb
otel-v1-apm-span-000001                23504     21.5mb
otel-v2-apm-service-map-000001           822    262.3kb

### 2. Spans by service (_search terms agg on serviceName)
total spans: 10000
  frontend: 9580
  load-generator: 4032
  cart: 3301
  product-catalog: 2174
  checkout: 1610
  flagd: 1490
  mcp-server: 1391
  travel-planner: 845
  product-reviews: 630
  recommendation: 498
  email: 468
  weather-agent: 446
  events-agent: 408
  quote: 351
  shipping: 351
  currency: 337
  fraud-detection: 237
  accounting: 234
  payment: 234
  ad: 52

### 3. Gen-AI spans (exists gen_ai.operation.name)
total gen_ai spans: 1409
operations: [('execute_tool', 703), ('invoke_agent', 482), ('chat', 224)]
models: [('claude-opus-4.5', 157), ('astronomy-llm', 49), ('claude-sonnet-4.5', 48), ('nova-premier', 42), ('gemini-2.5-pro', 38), ('o4-mini', 31), ('gemini-3-flash', 30), ('nova-pro', 21), ('gpt-4o-mini', 20), ('nova-lite', 19), ('gpt-4.1', 18), ('gpt-4.1-mini', 18)]
```

**Amazon Managed Prometheus** (workspace `ws-21292244…`, queried over SigV4)

```
### 4. APS metric catalog (/label/__name__/values)
distinct metric names: 387
sample app metrics: ['app_ads_ad_requests__total', 'app_cart_add_item_latency_seconds_bucket', 'app_cart_add_item_latency_seconds_count', 'app_cart_add_item_latency_seconds_max', 'app_cart_add_item_latency_seconds_min', 'app_cart_add_item_latency_seconds_sum', 'app_cart_get_cart_latency_seconds_bucket', 'app_cart_get_cart_latency_seconds_count']
gen_ai metrics: ['gen_ai_client_operation_duration_seconds_bucket', 'gen_ai_client_operation_duration_seconds_count', 'gen_ai_client_operation_duration_seconds_max', 'gen_ai_client_operation_duration_seconds_min', 'gen_ai_client_operation_duration_seconds_sum', 'gen_ai_client_token_usage_token_total']

### 5. APS instant queries (/query)
  http_server_request_duration_seconds_count: 7 series
  gen_ai_client_operation_duration_seconds_bucket: 31 series
  app_frontend_requests__total: 35 series
```

</details>

