### PR TITLE
fix(docs): update playground workspace and dataset IDs

### DIFF
--- a/docs/starlight-docs/src/config/playground.ts
+++ b/docs/starlight-docs/src/config/playground.ts
@@ -4,8 +4,8 @@
  * and every "Try in playground" link across all docs will update automatically.
  */
 export const PLAYGROUND = {
-  workspaceId: 'AYexAG',
-  datasetId: '6766d4f0-3869-11f1-b2f2-5f6bda0002a3',
+  workspaceId: '8xYRJ9',
+  datasetId: '5e9ecdd0-5418-11f1-ba61-c93b4ff6c8ce',
   datasetName: 'logs-otel-v1*',
   timeField: 'time',
 };


### PR DESCRIPTION
## What

The "Try in playground" links across the docs pointed at a Dashboards workspace and dataset that no longer exist. Updates both IDs in the single source of truth, `docs/starlight-docs/src/config/playground.ts`.

## Root cause

The playground moved to a new Dashboards workspace, `8xYRJ9`. Saved objects (including index patterns) are workspace-scoped, so the `logs-otel-v1*` index pattern has a different ID in the new workspace. The workspace ID and dataset ID the docs referenced no longer resolve, so every playground link opened a dead workspace or an empty dataset.

## Fix

Point `playground.ts` at the new workspace (`8xYRJ9`) and the `logs-otel-v1*` dataset ID in that workspace (`5e9ecdd0-5418-11f1-ba61-c93b4ff6c8ce`). `datasetName` (`logs-otel-v1*`) and `timeField` (`time`) are unchanged. `PlaygroundLink.astro` reads these values, so all links update at once.

## Validation

- Dataset ID confirmed against the workspace via the saved-objects `_find` API; `logs-otel-v1*` maps to `5e9ecdd0-...` on `time`.
- `npm run build` passes, internal link validator clean, and the built `dist/` output carries the new IDs.
- Each link below was loaded in a browser and returned live data.

Click to verify (each opens the new workspace and runs the PPL query):

- [Recent logs](https://observability.playground.opensearch.org/w/8xYRJ9/app/explore/logs/#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-6h,to:now))&_q=(dataset:(id:'5e9ecdd0-5418-11f1-ba61-c93b4ff6c8ce',timeFieldName:time,title:'logs-otel-v1*',type:INDEX_PATTERN),language:PPL,query:'%7C%20fields%20time%2C%20body%2C%20severityText%20%7C%20head%2020')&_a=(legacy:(columns:!(body,severityText,resource.attributes.service.name),interval:auto,isDirty:!f,sort:!()),tab:(logs:(),patterns:(usingRegexPatterns:!f)),ui:(activeTabId:logs,showHistogram:!t))) — `| fields time, body, severityText | head 20`
- [Log volume by service](https://observability.playground.opensearch.org/w/8xYRJ9/app/explore/logs/#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-6h,to:now))&_q=(dataset:(id:'5e9ecdd0-5418-11f1-ba61-c93b4ff6c8ce',timeFieldName:time,title:'logs-otel-v1*',type:INDEX_PATTERN),language:PPL,query:'%7C%20stats%20count%28%29%20by%20%60resource.attributes.service.name%60%20%7C%20sort%20-%20%60count%28%29%60')&_a=(legacy:(columns:!(body,severityText,resource.attributes.service.name),interval:auto,isDirty:!f,sort:!()),tab:(logs:(),patterns:(usingRegexPatterns:!f)),ui:(activeTabId:logs,showHistogram:!t))) — `| stats count() by \`resource.attributes.service.name\` | sort - \`count()\``
- [Errors only](https://observability.playground.opensearch.org/w/8xYRJ9/app/explore/logs/#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-6h,to:now))&_q=(dataset:(id:'5e9ecdd0-5418-11f1-ba61-c93b4ff6c8ce',timeFieldName:time,title:'logs-otel-v1*',type:INDEX_PATTERN),language:PPL,query:'%7C%20where%20severityText%20%3D%20%21%27ERROR%21%27%20%7C%20fields%20time%2C%20body%2C%20%60resource.attributes.service.name%60%20%7C%20head%2020')&_a=(legacy:(columns:!(body,severityText,resource.attributes.service.name),interval:auto,isDirty:!f,sort:!()),tab:(logs:(),patterns:(usingRegexPatterns:!f)),ui:(activeTabId:logs,showHistogram:!t))) — `| where severityText = 'ERROR' | fields time, body, \`resource.attributes.service.name\` | head 20`
