### PR TITLE
chore(release): bump CLI to 0.2.1

### DIFF
--- a/aws/cli-installer/package-lock.json
+++ b/aws/cli-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@opensearch-project/observability-stack",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@opensearch-project/observability-stack",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-js": "^5.2.0",

--- a/aws/cli-installer/package.json
+++ b/aws/cli-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensearch-project/observability-stack",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "CLI for the Observability Stack",
   "type": "module",
   "bin": "./bin/cli-installer.mjs",

--- a/aws/cli-installer/src/aws.mjs
+++ b/aws/cli-installer/src/aws.mjs
@@ -1762,24 +1762,16 @@ export function permissionsAllowInternet(permissions, port) {
 }
 
 /**
- * Analyze the security groups the stack attaches to the EC2 demo, OSIS pipeline,
- * and OpenSearch domain, and return WARNING strings for rules that would silently
- * break the data path. Pure: takes the DescribeSecurityGroups result so it is
- * unit-testable. Warnings only, never hard-fails: a user's network may route the
- * same traffic via other groups, a NAT, or NACLs we can't see.
- *
- * All three components share `groupIds` (see ec2-demo.mjs / createOsiPipeline /
- * createOpenSearch). There are two distinct egress needs, only one of which is
- * intra-VPC:
- *   - Intra-VPC egress 443 (always): OSIS reaches the domain; with a demo, the
- *     demo's collector reaches the VPC-private OSIS ingest endpoint. Satisfied by
- *     a self-reference, a VPC-CIDR rule, or 0.0.0.0/0.
- *   - Internet egress 443 (only with a demo): the instance bootstraps over the
- *     public internet (dnf, GitHub clone, container image pulls). This traffic
- *     does NOT flow through the VPC-private endpoint, so only a 0.0.0.0/0 egress
- *     rule (to a NAT/IGW) satisfies it; a VPC-CIDR-scoped rule does not.
- * Plus intra-VPC ingress 443 (always): OSIS accepts OTLP from the demo and the
- * domain accepts requests from OSIS.
+ * Return WARNING strings for security-group rules that break the stack's data
+ * path. Pure (takes the DescribeSecurityGroups result). Warnings only: a user's
+ * network may route the same traffic via other groups, a NAT, or NACLs we can't
+ * see. The EC2 demo, OSIS, and domain share `groupIds`, so the union must allow:
+ *   - Intra-VPC egress 443 (always): OSIS to domain; with a demo, demo collector
+ *     to the VPC-private OSIS ingest. Any of self-ref, VPC-CIDR, or 0.0.0.0/0.
+ *   - Internet egress 443 (demo only): the instance bootstraps over the public
+ *     internet (dnf, GitHub, image pulls), which does not use the VPC-private
+ *     endpoint. Only 0.0.0.0/0 (via a NAT/IGW) satisfies it, not a VPC-CIDR rule.
+ *   - Intra-VPC ingress 443 (always): OSIS from the demo, domain from OSIS.
  *
  * @param {object[]} groups  DescribeSecurityGroups result
  * @param {object} opts

--- a/aws/cli-installer/src/main.mjs
+++ b/aws/cli-installer/src/main.mjs
@@ -110,10 +110,8 @@ export async function executePipeline(cfg) {
     }
     printSuccess('VPC, subnets, and security groups validated');
 
-    // Best-effort: the topology check above proves the SGs exist and belong to
-    // the VPC, but not that their rules permit the 443 data path. A stripped
-    // egress rule leaves the demo unable to send anything out: no error, just
-    // no data. Warn (never block) before the ~30-min build so it's caught early.
+    // Topology validation proves the SGs exist and belong to the VPC, not that
+    // their rules permit the 443 data path. Warn before the ~30-min build.
     const sgWarnings = await checkSecurityGroupRules(cfg);
     for (const w of sgWarnings) printWarning(w);
     console.error();

--- a/aws/cli-installer/test/e2e/e2e-unit.test.mjs
+++ b/aws/cli-installer/test/e2e/e2e-unit.test.mjs
@@ -1,5 +1,5 @@
 /**
- * Unit tests for the PURE parts of the e2e harness — arg construction, the
+ * Unit tests for the PURE parts of the e2e harness: arg construction, the
  * scenario matrix, count evaluation, and synthetic OTLP payloads. These run
  * anywhere (no AWS, no credentials) and guard the harness logic itself.
  *
@@ -51,7 +51,7 @@ describe('scenario matrix', () => {
 
   it('the VPC no-demo scenario does not verify data flow (private ingest unreachable from outside)', () => {
     // A VPC-attached OSIS ingest endpoint is VPC-private, so a synthetic push from
-    // the runner host can never reach it — verifying data flow there would be a
+    // the runner host can never reach it, so verifying data flow there would be a
     // guaranteed false failure. VPC data flow is proven by the in-VPC demo instead.
     assert.equal(getScenario('managed-vpc-nodemo').verifyDataFlow, false);
     assert.equal(getScenario('managed-vpc-demo').verifyDataFlow, true);
@@ -174,7 +174,7 @@ describe('buildCreateArgs', () => {
 
   it('produces args that validateConfig accepts and resolve a full stack (integration with cli.mjs)', async () => {
     // Cross-check: the args we build should parse and validate cleanly, AND once
-    // defaults are applied they must resolve into an actionable full stack — an
+    // defaults are applied they must resolve into an actionable full stack: an
     // OSI role, an APS workspace, and an app. This guards against a regression
     // where the harness selected --advanced and left iamAction empty, which made
     // the CLI create only the domain and then fail deep in OSIS pipeline creation

--- a/aws/cli-installer/test/e2e/run.mjs
+++ b/aws/cli-installer/test/e2e/run.mjs
@@ -9,11 +9,11 @@
  *
  * For each selected scenario it:
  *   1. creates the stack via the real CLI (`bin/cli-installer.mjs`),
- *   2. drives telemetry in — the EC2 OTel-demo (demo scenarios) or a synthetic
+ *   2. drives telemetry in: the EC2 OTel-demo (demo scenarios) or a synthetic
  *      OTLP push (no-demo scenarios),
  *   3. verifies documents land in the expected OpenSearch indices by querying
  *      through the managed OpenSearch UI endpoint (works for VPC-private domains),
- *   4. tears the stack down — always, even on failure (unless --no-teardown).
+ *   4. tears the stack down, always, even on failure (unless --no-teardown).
  *
  * Usage:
  *   AWS_PROFILE=<sandbox> node test/e2e/run.mjs [options]
@@ -74,7 +74,7 @@ function runCli(args) {
   });
 }
 
-/** Short run id from the current time — collision-avoidance suffix for names. */
+/** Short run id from the current time; collision-avoidance suffix for names. */
 function runSuffix() {
   return Math.floor(Date.now() / 1000).toString(36).slice(-5);
 }
@@ -84,7 +84,7 @@ async function verifyScenario(scenario, { pipelineName, region, dataTimeoutMs })
   const os = new OpenSearchClient({ region });
   const { ApplicationSummaries } = await os.send(new ListApplicationsCommand({}));
   const app = (ApplicationSummaries || []).find((a) => a.name === pipelineName);
-  if (!app) throw new Error('OpenSearch Application not found — cannot verify data flow');
+  if (!app) throw new Error('OpenSearch Application not found; cannot verify data flow');
   const { endpoint: appEndpoint } = await os.send(new GetApplicationCommand({ id: app.id }));
   if (!appEndpoint) throw new Error('OpenSearch Application endpoint not populated');
   log(scenario.name, `app endpoint: ${appEndpoint}`);
@@ -159,7 +159,7 @@ async function main() {
 
   for (const scenario of selected) {
     if (scenario.vpc && !vpc) {
-      log(scenario.name, 'SKIP — VPC env vars not set (E2E_VPC_ID / E2E_SUBNET_IDS / E2E_SECURITY_GROUP_IDS)');
+      log(scenario.name, 'SKIP: VPC env vars not set (E2E_VPC_ID / E2E_SUBNET_IDS / E2E_SECURITY_GROUP_IDS)');
       summary.push({ scenario: scenario.name, status: 'skipped', reason: 'no VPC env' });
       continue;
     }
@@ -178,8 +178,8 @@ async function main() {
 
       if (scenario.verifyDataFlow === false) {
         // Data-flow verification isn't applicable (e.g. a VPC-private ingest
-        // endpoint the runner host can't reach). A clean create — the CLI exits 0
-        // only after every resource, including the pipeline reaching ACTIVE — plus
+        // endpoint the runner host can't reach). A clean create (the CLI exits 0
+        // only after every resource, including the pipeline reaching ACTIVE) plus
         // the teardown below is what this scenario proves.
         status = 'passed';
         detail = 'created (data-flow verification not applicable; teardown exercised)';
@@ -203,13 +203,13 @@ async function main() {
       if (opts.teardown) {
         log(scenario.name, 'tearing down...');
         const code = await runCli(buildDestroyArgs(scenario, base));
-        if (code !== 0) log(scenario.name, `WARNING: destroy exited ${code} — check for leftover resources`);
+        if (code !== 0) log(scenario.name, `WARNING: destroy exited ${code}; check for leftover resources`);
       } else {
-        log(scenario.name, 'teardown skipped (--no-teardown) — remember to destroy manually');
+        log(scenario.name, 'teardown skipped (--no-teardown); remember to destroy manually');
       }
     }
 
-    log(scenario.name, `=== ${status.toUpperCase()} — ${detail} ===\n`);
+    log(scenario.name, `=== ${status.toUpperCase()}: ${detail} ===\n`);
     summary.push({ scenario: scenario.name, status, detail });
   }
 

--- a/aws/cli-installer/test/e2e/scenarios.mjs
+++ b/aws/cli-installer/test/e2e/scenarios.mjs
@@ -62,7 +62,7 @@ export const SCENARIOS = [
   },
   {
     name: 'managed-vpc-nodemo',
-    description: 'Managed domain in a VPC (private endpoints), no demo — create/destroy only',
+    description: 'Managed domain in a VPC (private endpoints), no demo (create/destroy only)',
     backend: 'managed',
     vpc: true,
     demo: false,
@@ -70,7 +70,7 @@ export const SCENARIOS = [
     // A VPC-attached OSIS pipeline exposes a VPC-PRIVATE ingest endpoint (resolves
     // to RFC-1918 addresses reachable only inside the VPC). The synthetic OTLP push
     // originates from the developer's host, which has no route into the VPC, so it
-    // can never reach that endpoint — data-flow verification is not applicable here.
+    // can never reach that endpoint, so data-flow verification is not applicable here.
     // This scenario therefore exercises create + the full teardown path only (the
     // CLI still proves the VPC-attached pipeline reaches ACTIVE before exiting 0).
     // Use managed-vpc-demo to verify actual VPC data flow (demo runs in-VPC).
@@ -142,7 +142,7 @@ export function buildPipelineName(scenario, suffix) {
  * @param {object} opts
  * @param {string} opts.pipelineName
  * @param {string} opts.region
- * @param {object|null} [opts.vpc]  { vpcId, subnetIds[], securityGroupIds[] } — required if scenario.vpc
+ * @param {object|null} [opts.vpc]  { vpcId, subnetIds[], securityGroupIds[] }, required if scenario.vpc
  * @returns {string[]} argv
  */
 export function buildCreateArgs(scenario, opts) {
@@ -150,7 +150,7 @@ export function buildCreateArgs(scenario, opts) {
   if (!pipelineName) throw new Error('buildCreateArgs: pipelineName is required');
   if (!region) throw new Error('buildCreateArgs: region is required');
 
-  // Quick mode (the default — no --advanced) is what we want here: it auto-creates
+  // Quick mode (the default, no --advanced) is what we want here: it auto-creates
   // the whole stack (IAM OSI role, APS workspace, Application) named after the
   // pipeline, while still honoring every explicit flag we pass below. Advanced mode
   // only creates the resources you name explicitly, so passing --advanced with just

--- a/aws/cli-installer/test/e2e/verify.mjs
+++ b/aws/cli-installer/test/e2e/verify.mjs
@@ -4,7 +4,7 @@
  * After a stack is created and telemetry is pushed (either by the EC2 OTel-demo
  * or a synthetic OTLP push), these helpers confirm that documents actually
  * landed in the expected OpenSearch indices by querying through the managed
- * OpenSearch UI (Application) endpoint — the same SigV4 proxy path the installer
+ * OpenSearch UI (Application) endpoint, the same SigV4 proxy path the installer
  * uses, which works even for VPC-private domains from outside the VPC.
  *
  * Pure helpers (index expectations, count evaluation, OTLP payload building) are
@@ -230,7 +230,7 @@ export async function waitForData({
     }
     last = evaluateCounts(counts, { requireSignals });
     const summary = last.results.map((r) => `${r.pattern}=${r.count}${r.required ? '' : '(opt)'}`).join(' ');
-    log(`counts: ${summary} — ${last.ok ? 'OK' : 'waiting'}`);
+    log(`counts: ${summary} (${last.ok ? 'OK' : 'waiting'})`);
     if (last.ok) return { ...last, elapsedMs: Date.now() - start };
     await new Promise((r) => setTimeout(r, intervalMs));
   }


### PR DESCRIPTION
### Description

* Patch release: bumps the CLI to `0.2.1`.
* Remove some AI slop from code comments and log lines.  


### Release steps (after merge)

Following `RELEASING.md`:

1. Tag the merged commit `v0.2.1` and push to upstream (the tag is the release trigger).
2. The `release-to-npm` job pauses on the `release-approval` environment; a required reviewer who is not the release author approves.
3. On approval it validates the version, runs tests, publishes the CLI to the `latest` npm dist-tag, and drafts the GitHub release. Fill notes with the component-version matrix from `.env`.

### Issues Resolved

N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
