### PR TITLE
fix(agent-eval-canary): constrain idna>=3.15 for CVE-2026-45409

### DIFF
--- a/docker-compose/agent-eval-canary/pyproject.toml
+++ b/docker-compose/agent-eval-canary/pyproject.toml
@@ -9,3 +9,9 @@ dependencies = [
     "opentelemetry-sdk",
     "opentelemetry-exporter-otlp-proto-grpc",
 ]
+
+[tool.uv]
+# CVE-2026-45409 (GHSA-65pc-fj4g-8rjx): idna.encode() DoS, fixed in 3.15.
+# idna is transitive (via requests, through the SDK) and not imported here,
+# so floor it as a constraint rather than a direct dependency.
+constraint-dependencies = ["idna>=3.15"]

--- a/docker-compose/agent-eval-canary/uv.lock
+++ b/docker-compose/agent-eval-canary/uv.lock
@@ -7,6 +7,9 @@ resolution-markers = [
     "python_full_version < '3.13'",
 ]
 
+[manifest]
+constraints = [{ name = "idna", specifier = ">=3.15" }]
+
 [[package]]
 name = "agent-eval-canary"
 version = "0.1.0"
@@ -237,11 +240,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Constrain `idna>=3.15` in `docker-compose/agent-eval-canary` and re-lock. `idna` resolves 3.11 -> 3.18.

## Root cause

`idna` is a transitive dependency via `opensearch-genai-observability-sdk-py` (SDK -> `requests` -> `idna`). The pinned 3.11 is affected by CVE-2026-45409 (GHSA-65pc-fj4g-8rjx): specially crafted input to `idna.encode()` bypasses the CVE-2024-3651 length guard and causes excessive CPU consumption. Fixed in idna 3.15.

## Fix

Added a `[tool.uv] constraint-dependencies = ["idna>=3.15"]` floor to the canary's `pyproject.toml` and regenerated `uv.lock`. A uv constraint floors the resolved transitive version without adding `idna` as a direct dependency, so it drops out once the SDK raises its own floor (tracked separately). The lock diff is limited to the constraint entry and the idna package block.

## Validation

```
cd docker-compose/agent-eval-canary
uv sync                          # resolved 26 packages, idna 3.11 -> 3.18
uv sync --frozen --no-dev        # Dockerfile build gate, passes
uv run python -c "import idna, importlib.metadata as m; print(m.version('idna'))"
# 3.18
```

The canary module imports cleanly against the new lock (SDK, OTel exporters, idna 3.18). The poll loop needs a live OpenSearch backend and was not exercised here.

Closes #241. Part of #357.
