### PR TITLE
fix(aws): clear install-path dependency CVEs in aws/cdk and aws/cli-installer

### DIFF
--- a/aws/cdk/package-lock.json
+++ b/aws/cdk/package-lock.json
@@ -12,33 +12,33 @@
         "@aws-sdk/credential-provider-node": "^3.700.0",
         "@aws-sdk/signature-v4": "^3.374.0",
         "@smithy/protocol-http": "^5.0.0",
-        "aws-cdk-lib": "^2.180.0",
+        "aws-cdk-lib": "^2.260.0",
         "constructs": "^10.0.0"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",
-        "aws-cdk": "^2.180.0",
+        "aws-cdk": "^2.1132.0",
         "esbuild": "^0.28.0",
         "ts-node": "^10.9.2",
         "typescript": "~5.7.0"
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.273",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.273.tgz",
-      "integrity": "sha512-X57HYUtHt9BQrlrzUNcMyRsDUCoakYNnY6qh5lNwRCHPtQoTfXmuISkfLk0AjLkcbS5lw1LLTQFiQhTDXfiTvg==",
+      "version": "2.2.282",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.282.tgz",
+      "integrity": "sha512-7hKMi5tTxDcKGIMIOq14PnY0GBcugW33Uh/2YHDZiEwSxLeFOCYBwhR+BFXONb/EJeVI3RETFgailNZbkcKF6g==",
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.1.tgz",
-      "integrity": "sha512-We4bmHaowOPHr+IQR4/FyTGjRfjgBj4ICMjtqmJeBDWad3Q/6St12NT07leNtyuukv2qMhtSZJQorD8KpKTwRA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.2.tgz",
+      "integrity": "sha512-pDiuqH+qY3zM9lhhLjbKJ1tnKOHzQ2V4Wr/3qsxyKeKAkuPMI/BVGvZG1PbrikUw949cGVTfVEt4ETKKYnrj0Q==",
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "53.28.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.28.0.tgz",
-      "integrity": "sha512-pZS+9bLGv2tCqcgxfA0WD3XjcqT3yE4ICvKeJEicw6aTdCxBl8FQ/AUsorY/6f2JrMS3kUQgvhXxA30MWcji0A==",
+      "version": "54.12.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-54.12.0.tgz",
+      "integrity": "sha512-u8G9RZGW7vWq0KpEj1MYAin8yc+Mw7wYU2UjM5C2juZIHavXcerj6q7UsoOWd0N2TWtBw9WT9w3gknqR1GzAmg==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -46,7 +46,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "jsonschema": "^1.5.0",
-        "semver": "^7.8.0"
+        "semver": "^7.8.5"
       },
       "engines": {
         "node": ">= 18.0.0"
@@ -61,7 +61,7 @@
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-      "version": "7.8.0",
+      "version": "7.8.5",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -1215,6 +1215,18 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-3.0.0.tgz",
+      "integrity": "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@smithy/config-resolver": {
       "version": "4.4.14",
       "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.14.tgz",
@@ -1973,6 +1985,18 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/anynum": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+      "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
@@ -1981,9 +2005,9 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk": {
-      "version": "2.1117.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1117.0.tgz",
-      "integrity": "sha512-2NbSDDw8LTkGv0uhEDffttmNvgyTAWV5EkLkyPUGAGECzBdwCmbgmRxSoUhbzxZ0XEd1eaqbdVTFRWgtsbj31g==",
+      "version": "2.1133.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1133.0.tgz",
+      "integrity": "sha512-DGlCBwqxSHTe1u/IoT5WV+Bbd2K3UhwFHsdMqb2nQa1fkJmaQgoNFu0It+p3HxyMWeW+gKsVzT5KcjQPQ6Kzuw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1994,9 +2018,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.251.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.251.0.tgz",
-      "integrity": "sha512-H1Jfz2Oyejn+yG24i+By9fZpYfg+E3h1XnFCF2wnt/MyGOTIePRph7MRGkX73ap10ERSpmd0Ly58OLVykFoSQA==",
+      "version": "2.260.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.260.0.tgz",
+      "integrity": "sha512-2PPG+hbPDot8+ibkb5Jl9y3OY5rBE6TFwjzOi+yEyU4ZG6u8bM4DDKhhBi/S20NqqSFDso9rH1txVJAdwXNiuQ==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "@aws-cdk/cloud-assembly-api",
@@ -2013,19 +2037,19 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "2.2.273",
-        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.1",
-        "@aws-cdk/cloud-assembly-api": "^2.2.2",
-        "@aws-cdk/cloud-assembly-schema": "^53.18.0",
+        "@aws-cdk/asset-awscli-v1": "2.2.282",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.2",
+        "@aws-cdk/cloud-assembly-api": "^2.2.5",
+        "@aws-cdk/cloud-assembly-schema": "^54.0.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
-        "fs-extra": "^11.3.3",
+        "fs-extra": "^11.3.5",
         "ignore": "^5.3.2",
         "jsonschema": "^1.5.0",
         "mime-types": "^2.1.35",
-        "minimatch": "^10.2.3",
+        "minimatch": "^10.2.5",
         "punycode": "^2.3.1",
-        "semver": "^7.7.4",
+        "semver": "^7.8.1",
         "table": "^6.9.0",
         "yaml": "1.10.3"
       },
@@ -2037,41 +2061,18 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
-      "version": "2.2.2",
-      "bundleDependencies": [
-        "jsonschema",
-        "semver"
-      ],
+      "version": "2.2.5",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "jsonschema": "~1.4.1",
-        "semver": "^7.7.4"
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.0"
       },
       "engines": {
         "node": ">= 18.0.0"
       },
       "peerDependencies": {
-        "@aws-cdk/cloud-assembly-schema": ">=53.15.0"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/jsonschema": {
-      "version": "1.4.1",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/semver": {
-      "version": "7.7.4",
-      "inBundle": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
+        "@aws-cdk/cloud-assembly-schema": ">=53.28.0"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
@@ -2080,7 +2081,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/aws-cdk-lib/node_modules/ajv": {
-      "version": "8.18.0",
+      "version": "8.20.0",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -2133,7 +2134,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
-      "version": "5.0.5",
+      "version": "5.0.6",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -2178,7 +2179,7 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/fast-uri": {
-      "version": "3.1.0",
+      "version": "3.1.2",
       "funding": [
         {
           "type": "github",
@@ -2193,7 +2194,7 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
-      "version": "11.3.3",
+      "version": "11.3.5",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -2232,7 +2233,7 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/jsonfile": {
-      "version": "6.2.0",
+      "version": "6.2.1",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -2305,7 +2306,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.7.4",
+      "version": "7.8.1",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -2474,9 +2475,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.8",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
-      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.10.1.tgz",
+      "integrity": "sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==",
       "funding": [
         {
           "type": "github",
@@ -2485,13 +2486,43 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.2.0",
-        "strnum": "^2.2.0"
+        "@nodable/entities": "^3.0.0",
+        "fast-xml-builder": "^1.2.0",
+        "is-unsafe": "^2.0.0",
+        "path-expression-matcher": "^1.6.2",
+        "strnum": "^2.4.1",
+        "xml-naming": "^0.3.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
       }
+    },
+    "node_modules/fast-xml-parser/node_modules/xml-naming": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
+      "integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/is-unsafe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-2.0.0.tgz",
+      "integrity": "sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/make-error": {
       "version": "1.3.6",
@@ -2501,9 +2532,9 @@
       "license": "ISC"
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
-      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
+      "integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
       "funding": [
         {
           "type": "github",
@@ -2516,16 +2547,19 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
-      "integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+      "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.1"
+      }
     },
     "node_modules/ts-node": {
       "version": "10.9.2",

--- a/aws/cdk/package.json
+++ b/aws/cdk/package.json
@@ -14,14 +14,17 @@
     "@aws-sdk/credential-provider-node": "^3.700.0",
     "@aws-sdk/signature-v4": "^3.374.0",
     "@smithy/protocol-http": "^5.0.0",
-    "aws-cdk-lib": "^2.180.0",
+    "aws-cdk-lib": "^2.260.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",
-    "aws-cdk": "^2.180.0",
+    "aws-cdk": "^2.1132.0",
     "esbuild": "^0.28.0",
     "ts-node": "^10.9.2",
     "typescript": "~5.7.0"
+  },
+  "overrides": {
+    "fast-xml-parser": "^5.7.0"
   }
 }

--- a/aws/cli-installer/package-lock.json
+++ b/aws/cli-installer/package-lock.json
@@ -743,39 +743,43 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.973.26",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.26.tgz",
-      "integrity": "sha512-A/E6n2W42ruU+sfWk+mMUOyVXbsSgGrY3MJ9/0Az5qUdG67y8I6HYzzoAa+e/lzxxl1uCYmEL6BTMi9ZiZnplQ==",
+      "version": "3.977.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.1.tgz",
+      "integrity": "sha512-KVtQRtc00ES/y+Sc3vYXeP6pCIcNlBJCZOwvqSy8ZpVGmbM5+IG+AfhuTKQ2oXmIVqZJewaGMMpzPkywC6xg0w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/xml-builder": "^3.972.16",
-        "@smithy/core": "^3.23.13",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/signature-v4": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.8",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-utf8": "^4.2.2",
+        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/xml-builder": "^3.972.37",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.29.8",
+        "@smithy/signature-v4": "^5.6.9",
+        "@smithy/types": "^4.16.1",
+        "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/core/node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.24",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.24.tgz",
-      "integrity": "sha512-FWg8uFmT6vQM7VuzELzwVo5bzExGaKHdubn0StjgrcU5FvuLExUe+k06kn/40uKv59rYzhez8eFNM4yYE/Yb/w==",
+      "version": "3.972.62",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.62.tgz",
+      "integrity": "sha512-BkDrk2cNjed31IKin/Oksb2ziF+gfuyRskFVuT4EU9Mep7M8Y/d8DJG4+anHme4Vuse7CwaEscwEfGyR6mzBhQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.977.1",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -783,20 +787,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.26",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.26.tgz",
-      "integrity": "sha512-CY4ppZ+qHYqcXqBVi//sdHST1QK3KzOEiLtpLsc9W2k2vfZPKExGaQIsOwcyvjpjUEolotitmd3mUNY56IwDEA==",
+      "version": "3.972.64",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.64.tgz",
+      "integrity": "sha512-Wj1FGK2IxY5EccQCvH+niTYhIvDoDujJf2CpRRgS3NpYNEgiFNVItNbJYQjINRlu7fG7jSsXkKV0UWKriEplrw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/node-http-handler": "^4.5.1",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.8",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-stream": "^4.5.21",
+        "@aws-sdk/core": "^3.977.1",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/fetch-http-handler": "^5.6.10",
+        "@smithy/node-http-handler": "^4.9.10",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -804,24 +805,23 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.28",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.28.tgz",
-      "integrity": "sha512-wXYvq3+uQcZV7k+bE4yDXCTBdzWTU9x/nMiKBfzInmv6yYK1veMK0AKvRfRBd72nGWYKcL6AxwiPg9z/pYlgpw==",
+      "version": "3.973.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.7.tgz",
+      "integrity": "sha512-2CefB8cCxDu52P24B8Ay93/cTT199bcSvNHQ8e2f4BjSCF83yErBnTIZEBo0VeIgCfmw+PJKFUXnlQWxm2dkug==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/credential-provider-env": "^3.972.24",
-        "@aws-sdk/credential-provider-http": "^3.972.26",
-        "@aws-sdk/credential-provider-login": "^3.972.28",
-        "@aws-sdk/credential-provider-process": "^3.972.24",
-        "@aws-sdk/credential-provider-sso": "^3.972.28",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.28",
-        "@aws-sdk/nested-clients": "^3.996.18",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/credential-provider-imds": "^4.2.12",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.977.1",
+        "@aws-sdk/credential-provider-env": "^3.972.62",
+        "@aws-sdk/credential-provider-http": "^3.972.64",
+        "@aws-sdk/credential-provider-login": "^3.972.69",
+        "@aws-sdk/credential-provider-process": "^3.972.62",
+        "@aws-sdk/credential-provider-sso": "^3.973.6",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.68",
+        "@aws-sdk/nested-clients": "^3.997.36",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/credential-provider-imds": "^4.4.13",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -829,18 +829,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.28",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.28.tgz",
-      "integrity": "sha512-ZSTfO6jqUTCysbdBPtEX5OUR//3rbD0lN7jO3sQeS2Gjr/Y+DT6SbIJ0oT2cemNw3UzKu97sNONd1CwNMthuZQ==",
+      "version": "3.972.69",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.69.tgz",
+      "integrity": "sha512-gM3j0Ie9+FoLNTYODY+QWbg3vCRBc7mR9cRdntxTMkFYIrwfRmuucfavP6HNBlYSuaYww54TNJGej4GFgoPZAg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/nested-clients": "^3.996.18",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.977.1",
+        "@aws-sdk/nested-clients": "^3.997.36",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -848,22 +846,22 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.29.tgz",
-      "integrity": "sha512-clSzDcvndpFJAggLDnDb36sPdlZYyEs5Zm6zgZjjUhwsJgSWiWKwFIXUVBcbruidNyBdbpOv2tNDL9sX8y3/0g==",
+      "version": "3.972.30",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.30.tgz",
+      "integrity": "sha512-FMnAnWxc8PG+ZrZ2OBKzY4luCUJhe9CG0B9YwYr4pzrYGLXBS2rl+UoUvjGbAwiptxRL6hyA3lFn03Bv1TLqTw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.24",
-        "@aws-sdk/credential-provider-http": "^3.972.26",
-        "@aws-sdk/credential-provider-ini": "^3.972.28",
-        "@aws-sdk/credential-provider-process": "^3.972.24",
-        "@aws-sdk/credential-provider-sso": "^3.972.28",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.28",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/credential-provider-imds": "^4.2.12",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/credential-provider-env": "^3.972.25",
+        "@aws-sdk/credential-provider-http": "^3.972.27",
+        "@aws-sdk/credential-provider-ini": "^3.972.29",
+        "@aws-sdk/credential-provider-process": "^3.972.25",
+        "@aws-sdk/credential-provider-sso": "^3.972.29",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.29",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/credential-provider-imds": "^4.2.13",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/shared-ini-file-loader": "^4.4.8",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -871,16 +869,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.24",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.24.tgz",
-      "integrity": "sha512-Q2k/XLrFXhEztPHqj4SLCNID3hEPdlhh1CDLBpNnM+1L8fq7P+yON9/9M1IGN/dA5W45v44ylERfXtDAlmMNmw==",
+      "version": "3.972.62",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.62.tgz",
+      "integrity": "sha512-zXYU9UWNL66gtMgNLhmxlrvEokuI7r6G2q7FRGu41Bya4iS30JLelUipJX9SV4zhyCPWJhI9Li54R1d9H8Tq6A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.977.1",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -888,18 +885,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.28",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.28.tgz",
-      "integrity": "sha512-IoUlmKMLEITFn1SiCTjPfR6KrE799FBo5baWyk/5Ppar2yXZoUdaRqZzJzK6TcJxx450M8m8DbpddRVYlp5R/A==",
+      "version": "3.973.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.6.tgz",
+      "integrity": "sha512-DobZggy3K49xdCpjeyMou0FQhkoYbluVGNydL6D+lcxF8GoAsttFX0xnH5GmiQ89We5dB6TRpW+CD/VowBH6HQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/nested-clients": "^3.996.18",
-        "@aws-sdk/token-providers": "3.1021.0",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.977.1",
+        "@aws-sdk/nested-clients": "^3.997.36",
+        "@aws-sdk/token-providers": "3.1096.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -907,17 +903,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.28",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.28.tgz",
-      "integrity": "sha512-d+6h0SD8GGERzKe27v5rOzNGKOl0D+l0bWJdqrxH8WSQzHzjsQFIAPgIeOTUwBHVsKKwtSxc91K/SWax6XgswQ==",
+      "version": "3.972.68",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.68.tgz",
+      "integrity": "sha512-bq+yTt+uWJx60VVp/OIAX5xqUAu/K2Uc3eknWnWl+KtfcU2CQe0uNw6lySrn2t5GKHq7jsV0Z63HiBGVtzr/lg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/nested-clients": "^3.996.18",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.977.1",
+        "@aws-sdk/nested-clients": "^3.997.36",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1057,48 +1052,18 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.996.18",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.18.tgz",
-      "integrity": "sha512-c7ZSIXrESxHKx2Mcopgd8AlzZgoXMr20fkx5ViPWPOLBvmyhw9VwJx/Govg8Ef/IhEon5R9l53Z8fdYSEmp6VA==",
+      "version": "3.997.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.36.tgz",
+      "integrity": "sha512-b71Suv7L+DnhM0MsQHU4WO42I32kxLZi96PbVhZbxMYIoKnEZz3v+LSrG8fupAoA4cBSshCk1Dl/PeRz49qUSg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/middleware-host-header": "^3.972.8",
-        "@aws-sdk/middleware-logger": "^3.972.8",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.9",
-        "@aws-sdk/middleware-user-agent": "^3.972.28",
-        "@aws-sdk/region-config-resolver": "^3.972.10",
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/util-endpoints": "^3.996.5",
-        "@aws-sdk/util-user-agent-browser": "^3.972.8",
-        "@aws-sdk/util-user-agent-node": "^3.973.14",
-        "@smithy/config-resolver": "^4.4.13",
-        "@smithy/core": "^3.23.13",
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/hash-node": "^4.2.12",
-        "@smithy/invalid-dependency": "^4.2.12",
-        "@smithy/middleware-content-length": "^4.2.12",
-        "@smithy/middleware-endpoint": "^4.4.28",
-        "@smithy/middleware-retry": "^4.4.46",
-        "@smithy/middleware-serde": "^4.2.16",
-        "@smithy/middleware-stack": "^4.2.12",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/node-http-handler": "^4.5.1",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.8",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.44",
-        "@smithy/util-defaults-mode-node": "^4.2.48",
-        "@smithy/util-endpoints": "^3.3.3",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-retry": "^4.2.13",
-        "@smithy/util-utf8": "^4.2.2",
+        "@aws-sdk/core": "^3.977.1",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.42",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/fetch-http-handler": "^5.6.10",
+        "@smithy/node-http-handler": "^4.9.10",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1140,6 +1105,21 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.42.tgz",
+      "integrity": "sha512-DBV4naZP6HYBlAvPpoQzOP12Wvfou/5rN8yJPXjBTBylU5qwCbh/tXr2MddHoIjgoRkEl/eS+IljiUqvmwey1Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/signature-v4": "^5.6.9",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/signature-v4/node_modules/@aws-sdk/types": {
       "version": "3.370.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.370.0.tgz",
@@ -1166,17 +1146,16 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1021.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1021.0.tgz",
-      "integrity": "sha512-TKY6h9spUk3OLs5v1oAgW9mAeBE3LAGNBwJokLy96wwmd4W2v/tYlXseProyed9ValDj2u1jK/4Rg1T+1NXyJA==",
+      "version": "3.1096.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1096.0.tgz",
+      "integrity": "sha512-hdUS2hDppy3vkWeFl5y86RLNU6OWH2mQB09yOSsRefwhhGTSFPkaZvfLDD/9vFcvMzlr8QFQFw3fw2FtrurVQA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/nested-clients": "^3.996.18",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.977.1",
+        "@aws-sdk/nested-clients": "^3.997.36",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1184,12 +1163,12 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.6.tgz",
-      "integrity": "sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==",
+      "version": "3.974.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
+      "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1348,13 +1327,12 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.16",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.16.tgz",
-      "integrity": "sha512-iu2pyvaqmeatIJLURLqx9D+4jKAdTH20ntzB6BFwjyN7V960r4jK32mx0Zf7YbtOYAbmbtQfDNuL60ONinyw7A==",
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.37.tgz",
+      "integrity": "sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
-        "fast-xml-parser": "5.5.8",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1722,20 +1700,12 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.23.13",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.13.tgz",
-      "integrity": "sha512-J+2TT9D6oGsUVXVEMvz8h2EmdVnkBiy2auCie4aSJMvKlzUtO5hqjEzXhoCUkIMo7gAYjbQcN0g/MMSXEhDs1Q==",
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.30.0.tgz",
+      "integrity": "sha512-dl2yRglDxfzH9uJ4fSo4zTaAHa0zH7+V7BZMRWy8hEYIKT1BiqMUK/CN6T3ADQ3kbA5N1tmUulroJ2UtONS7Kw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-stream": "^4.5.21",
-        "@smithy/util-utf8": "^4.2.2",
-        "@smithy/uuid": "^1.1.2",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1743,15 +1713,13 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.12.tgz",
-      "integrity": "sha512-cr2lR792vNZcYMriSIj+Um3x9KWrjcu98kn234xA6reOAFMmbRpQMOv8KPgEmLLtx3eldU6c5wALKFqNOhugmg==",
+      "version": "4.4.14",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.14.tgz",
+      "integrity": "sha512-QgbuahIb2qxQeZQvNK0sw3aF3JH5zwH8j2lLp5DUasVXexGGMWULAR+7z0omPXFolCP/m5wN9M5lm9EGdSviTQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
+        "@smithy/core": "^3.30.0",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1759,15 +1727,13 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.3.15",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.15.tgz",
-      "integrity": "sha512-T4jFU5N/yiIfrtrsb9uOQn7RdELdM/7HbyLNr6uO/mpkj1ctiVs7CihVr51w4LyQlXWDpXFn4BElf1WmQvZu/A==",
+      "version": "5.6.11",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.11.tgz",
+      "integrity": "sha512-o0Zkj1nKqJAoq+a+BrkhU39tRftMNjLwpc/z06Frfl43wpbHrJMaSAVZE4vTqlxtVkNaGaT0bIDxOp7tkFTuQQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/querystring-builder": "^4.2.12",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-base64": "^4.3.2",
+        "@smithy/core": "^3.30.0",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1911,14 +1877,13 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.5.1.tgz",
-      "integrity": "sha512-ejjxdAXjkPIs9lyYyVutOGNOraqUE9v/NjGMKwwFrfOM354wfSD8lmlj8hVwUzQmlLLF4+udhfCX9Exnbmvfzw==",
+      "version": "4.9.11",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.11.tgz",
+      "integrity": "sha512-slbzbz8taEOzoXv/9y34YNBoE+ZHmddLykCgjDAjvMAsu2nM5s2Gzwa5OGF721tD8s+CKeFUBds5lSj9lcbuDg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/querystring-builder": "^4.2.12",
-        "@smithy/types": "^4.13.1",
+        "@smithy/core": "^3.30.0",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1926,12 +1891,12 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.12.tgz",
-      "integrity": "sha512-jqve46eYU1v7pZ5BM+fmkbq3DerkSluPr5EhvOcHxygxzD05ByDRppRwRPPpFrsFo5yDtCYLKu+kreHKVrvc7A==",
+      "version": "4.4.14",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.4.14.tgz",
+      "integrity": "sha512-zF/MIfH99pVoYWZedI87udXf3NpSf8xvwIWD77rQ3qcD7rpCxyabweinDJw1DRGN+vdQ/LcolY87L4rsJ/gPdA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/core": "^3.30.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1991,12 +1956,12 @@
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.4.7",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.7.tgz",
-      "integrity": "sha512-HrOKWsUb+otTeo1HxVWeEb99t5ER1XrBi/xka2Wv6NVmTbuCUC1dvlrksdvxFtODLBjsC+PHK+fuy2x/7Ynyiw==",
+      "version": "4.6.14",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.6.14.tgz",
+      "integrity": "sha512-/rg/ksfMpLzG9fK67n+98OsyFHME7j6jW/3NwIRVTv2C5YAbHQUFxutBnmq7rWFoB2qojDShgTv+i1JeGXJS6A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/core": "^3.30.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2004,18 +1969,13 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.12.tgz",
-      "integrity": "sha512-B/FBwO3MVOL00DaRSXfXfa/TRXRheagt/q5A2NM13u7q+sHS59EOVGQNfG7DkmVtdQm5m3vOosoKAXSqn/OEgw==",
+      "version": "5.6.10",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.10.tgz",
+      "integrity": "sha512-EXhWePm3SXJAX38npIy4TXL2Aex/OVgCClTjelN2QHw/U+8CQUH8C7AaxsVzQcYieYPseywn48s89DmvuGjiAg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.2",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-hex-encoding": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-uri-escape": "^4.2.2",
-        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/core": "^3.30.0",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2041,9 +2001,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.1.tgz",
-      "integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -2404,42 +2364,6 @@
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "license": "MIT"
     },
-    "node_modules/fast-xml-builder": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
-      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "path-expression-matcher": "^1.5.0",
-        "xml-naming": "^0.1.0"
-      }
-    },
-    "node_modules/fast-xml-parser": {
-      "version": "5.5.8",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
-      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.2.0",
-        "strnum": "^2.2.0"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
-    },
     "node_modules/get-east-asian-width": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
@@ -2588,21 +2512,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/path-expression-matcher": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
-      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/restore-cursor": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
@@ -2681,18 +2590,6 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
-    "node_modules/strnum": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
-      "integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -2752,21 +2649,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/xml-naming": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
-      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.0.0"
       }
     },
     "node_modules/yoctocolors-cjs": {


### PR DESCRIPTION
## What

Clears the open Mend security alerts on the two user-facing AWS install manifests (`aws/cdk`, `aws/cli-installer`). These manifests are not watched by Dependabot, so the alerts sat open. This is the code users run to install the stack, so it is the highest-blast-radius path in the triage tracked by #357.

Consolidated into one PR because both manifests share the same `fast-xml-parser` root and the changes verify together. No major-version bumps.

## Changes

`aws/cdk`:
- `aws-cdk-lib` `^2.180.0` -> `^2.260.0`. Clears CVE-2026-13760 (direct) and the `fast-uri` advisories CVE-2026-6321/6322 (patched in cdk 2.252.0).
- `aws-cdk` CLI `^2.180.0` -> `^2.1132.0`. 2.260.0 emits cloud-assembly schema v54; the old CLI floor only reads v53, so `cdk synth` fails on a schema mismatch without this. Still a 2.x bump.
- `overrides.fast-xml-parser: ^5.7.0` (resolves 5.10.1). Clears CVE-2026-41650 on the `@aws-sdk` chain.

`aws/cli-installer`:
- `@aws-sdk/credential-provider-node` -> 3.972.30 (lockfile only). The newer `@aws-sdk/xml-builder` in that tree drops `fast-xml-parser` entirely, which clears CVE-2026-41650 at the source. No `fast-xml-parser` override is added here because a fresh re-lock resolves none, so an override would match nothing.

Supersedes bot PRs #335, #339, and #289, which each carry a subset of this fix.

## Residual cdk advisories (not fixable via npm overrides)

The `brace-expansion` and `fast-uri` advisories that remain on the cdk tree are `bundledDependencies` shipped inside the `aws-cdk-lib` tarball (via minimatch/ajv). npm `overrides` cannot rewrite bundled deps, so no override clears them. Even 2.262.1 bundles the flagged versions. Mend's own table on #293 marks these `Fixed in: N/A` for the same reason. They clear when aws-cdk-lib bundles patched versions upstream.

## Validation

`aws/cdk`: `npm install`, `npm run build`, `npm run synth` all pass. `synth` template shape is identical to main (ObsInfra 19 resources, ObservabilityStack 29; zero added, removed, or retyped resources). The only drift is CDK-internal: provider-framework helper Lambdas move `nodejs22.x` -> `nodejs24.x` and the CDKMetadata blob changes. All user resources are byte-identical after asset-hash normalization.

`aws/cli-installer`: `npm install`, `npm test` (134/134 pass), `npm run e2e:list` green, `npm audit` reports 0 vulnerabilities.

**e2e gap:** `npm run e2e` provisions billable live AWS infra (OpenSearch domains, EC2, OSIS) and was not run unattended. This change is a lockfile adoption on the installer plus a non-breaking cdk minor, covered by the unit suite and a clean audit. Requesting QA on the managed public e2e path before merge.

Closes #293 #214 #215
Refs #357
