### PR TITLE
chore(deps): pin dompurify, js-yaml, postcss-selector-parser in starlight-docs

### DIFF
--- a/docs/starlight-docs/package-lock.json
+++ b/docs/starlight-docs/package-lock.json
@@ -3433,9 +3433,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.5.tgz",
-      "integrity": "sha512-OrwIBKsdNSVEeubdJ1HBv/wNENRM9ytAVCv7YXt//A3vPdVMNuACRqK9mXCGCBW2ln7BT/A4X0jXHo2Gu89miA==",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -4443,9 +4443,19 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -6032,9 +6042,9 @@
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
-      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.4.tgz",
+      "integrity": "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",

--- a/docs/starlight-docs/package.json
+++ b/docs/starlight-docs/package.json
@@ -16,10 +16,5 @@
     "mermaid": "^11.15.0",
     "sharp": "^0.34.2",
     "starlight-links-validator": "^0.24.0"
-  },
-  "overrides": {
-    "dompurify": "3.4.12",
-    "js-yaml": "4.3.0",
-    "postcss-selector-parser": "^6.1.3"
   }
 }

--- a/docs/starlight-docs/package.json
+++ b/docs/starlight-docs/package.json
@@ -16,5 +16,10 @@
     "mermaid": "^11.15.0",
     "sharp": "^0.34.2",
     "starlight-links-validator": "^0.24.0"
+  },
+  "overrides": {
+    "dompurify": "3.4.12",
+    "js-yaml": "4.3.0",
+    "postcss-selector-parser": "^6.1.3"
   }
 }


### PR DESCRIPTION
## What

Pins three vulnerable transitive dependencies in the `docs/starlight-docs` lockfile via `package.json` overrides. All three bumps stay within their existing majors.

| Package | From | To | Advisory | Severity | Pulled in by |
|---|---|---|---|---|---|
| dompurify | 3.4.5 | 3.4.12 | CVE-2026-49978 (+8 more) | 9.3 CRITICAL | mermaid |
| js-yaml | 4.1.1 | 4.3.0 | CVE-2026-59869, CVE-2026-53550 | 7.5 HIGH | @astrojs/starlight |
| postcss-selector-parser | 6.1.2 | 6.1.4 | CVE-2026-9358 | 4.3 MEDIUM | postcss-nested |

Source alert: opensearch-project/observability-stack#357 (starlight-docs section). Tracking alerts: #258 (mermaid: dompurify, 9 CVEs, highest 9.3) and #278 (starlight: js-yaml + postcss-selector-parser, highest 7.5).

## Why overrides

dompurify and js-yaml resolve one lockfile refresh away from their patched versions, but `postcss-selector-parser` is a transitive dep of `postcss-nested` (`^6.1.1`); `npm install --package-lock-only` alone keeps it pinned at 6.1.2. An explicit `overrides` entry is required to move it. Per the CVE-2026-9358 advisory the fix was backported to the 6.x line in 6.1.3, so `^6.1.3` (resolving to 6.1.4) clears it without a major bump. The other two are placed in the same `overrides` block so the intended floor is auditable in the manifest, not only in the lockfile.

The astro-7 / starlight-0.41 supersets (#336, #356) are intentionally excluded; the astro v7 evaluation is tracked separately (#340, #327).

## Validation

Mirrors `docs-ci.yml`, Node 22:

- `npm ci && npm run build` (starlight): green, 135 pages, all internal links valid.
- Mermaid render check: 63 built pages carry `<pre class="mermaid">`, and the bundled `dist/_astro/mermaid.core.*.js` ships DOMPurify `3.4.12`. dompurify is mermaid's XSS sanitizer, so this confirms the patched sanitizer reaches the built output, not just the lockfile.
- `npm audit --omit=dev`: dompurify, js-yaml, and postcss-selector-parser all clear. Remaining audit entries (astro, esbuild, postcss, sharp, svgo, vite) are out of scope for this alert.
- `npm ls dompurify js-yaml postcss-selector-parser`: all three report `overridden` at the patched versions.

Closes #258, closes #278
