### PR TITLE
chore: auto-merge Dependabot patch/minor bumps under /examples/*

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,30 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]' && github.repository == 'opensearch-project/observability-stack'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Scope to the examples/ sample apps and patch/minor bumps only. Major
+      # bumps and any non-examples path fall through to manual review.
+      - name: Enable auto-merge for examples patch/minor bumps
+        if: |
+          startsWith(steps.metadata.outputs.directory, '/examples/') &&
+          (steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+           steps.metadata.outputs.update-type == 'version-update:semver-minor')
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

Adds `.github/workflows/dependabot-auto-merge.yml`. On a Dependabot PR, it enables GitHub native auto-merge (squash) when the bump is patch or minor AND the update targets a directory under `/examples/`. Major bumps and any non-examples path fall through to manual review.

## Why

The Dependabot backlog on the sample apps under `/examples/*` accumulates faster than anyone reviews it. These are sample-app dependencies, not stack code or security manifests, so patch/minor bumps are low risk to land automatically.

## How it works

Dependabot PRs come from same-repo branches, so `on: pull_request` with an elevated `permissions:` block (`contents: write`, `pull-requests: write`) gives the merge step a usable `GITHUB_TOKEN`. `dependabot/fetch-metadata` exposes `directory` and `update-type`; the merge step gates on both. The job `if` also pins to the upstream repo so the workflow is inert on forks.

## Prerequisites (repo/org settings, not in this PR)

Two settings outside this file must be in place for merges to land unattended:

1. Repo setting `Allow auto-merge` must be enabled (Settings > General > Pull Requests). `gh pr merge --auto` fails if it is off.
2. The org `global_dependabot` branch ruleset requires 1 code-owner approving review on `dependabot/**` branches. While that holds, a code owner still approves each PR; the workflow only removes the final merge click. To make examples patch/minor bumps fully unattended, the ruleset needs a carve-out for `dependabot/**` paths under `/examples/` (or accept the one-approval step).

## Validation

`actionlint` clean. Action pinned to the release SHA per repo convention (`dependabot/fetch-metadata@25dd0e3` = v3.1.0). Not exercised end to end against a live Dependabot PR yet; that requires the repo/org settings above.
