### PR TITLE
revert(aws/cdk): drop unnecessary aws-cdk CLI floor bump from #370

### DIFF
--- a/aws/cdk/package-lock.json
+++ b/aws/cdk/package-lock.json
@@ -17,7 +17,7 @@
       },
       "devDependencies": {
         "@types/node": "^25.5.0",
-        "aws-cdk": "^2.1133.0",
+        "aws-cdk": "^2.1132.0",
         "esbuild": "^0.28.1",
         "ts-node": "^10.9.2",
         "typescript": "~5.7.0"

--- a/aws/cdk/package.json
+++ b/aws/cdk/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.5.0",
-    "aws-cdk": "^2.1133.0",
+    "aws-cdk": "^2.1132.0",
     "esbuild": "^0.28.1",
     "ts-node": "^10.9.2",
     "typescript": "~5.7.0"


### PR DESCRIPTION
## What

Reverts one change from #370 that is not tied to any Dependabot alert: the `aws-cdk` (CLI) devDependency floor bump `^2.1132.0` → `^2.1133.0` in `aws/cdk`.

## Why it's unnecessary

Requested in [#370 review](https://github.com/opensearch-project/observability-stack/pull/370#issuecomment-5120611043) — check the CVE PR for unnecessary changes.

The aws/cdk alerts #370 set out to clear were:
- **fast-uri** (#319, #321) — a transitive of `aws-cdk-lib`, dropped by the `aws-cdk-lib ^2.262.1` bump (confirmed: pre-PR it sat at `node_modules/aws-cdk-lib/node_modules/fast-uri`; it's absent from the lockfile now).
- **esbuild** GHSA-67mh-4wv8-2f99 (#180) — cleared by the `esbuild ^0.28.1` bump.

The `aws-cdk` CLI floor bump clears neither. It's also a **no-op for the resolved tree**: both the pre-PR and post-PR lockfiles already resolve `aws-cdk` to `2.1133.0`, and `^2.1132.0` continues to permit `2.1133.0`. So this only narrows the manifest floor without changing what gets installed.

## Change

```diff
   "devDependencies": {
     "@types/node": "^25.5.0",
-    "aws-cdk": "^2.1133.0",
+    "aws-cdk": "^2.1132.0",
     "esbuild": "^0.28.1",
```

Lockfile mirrors the same range; resolved `aws-cdk` stays `2.1133.0` (matches base), so no install/CI behavior changes.

## Not reverted (verified necessary / intended)

- **`requires-python` `>=3.9` → `>=3.10`** in `examples/plain-agents/weather-agent`: **necessary**. Reverting it makes `uv lock` unsatisfiable — the CVE constraint `starlette>=1.3.1` forces `fastapi>=0.129.0`, which requires Python `>=3.10`.
- **`.github/dependabot.yml`** coverage-gap additions: intended part of #370 (documented as the "coverage gap" fix).
- All `astro`/`sharp`/`svgo`/`postcss`/`vite`/`esbuild` bumps and overrides: each maps to a listed advisory.