### PR TITLE
fix: populate index-pattern field lists

### DIFF
--- a/charts/observability-stack/files/init-opensearch-dashboards.py
+++ b/charts/observability-stack/files/init-opensearch-dashboards.py
@@ -1920,14 +1920,19 @@ def refresh_index_pattern_fields(workspace_id, pattern_id, title):
         return False
 
     if workspace_id and workspace_id != "default":
-        url = f"{BASE_URL}/w/{workspace_id}/api/index_patterns/_fields_for_wildcard?pattern={title}&meta_fields=_source&meta_fields=_id&meta_fields=_type&meta_fields=_index&meta_fields=_score"
+        url = f"{BASE_URL}/w/{workspace_id}/api/index_patterns/_fields_for_wildcard"
     else:
-        url = f"{BASE_URL}/api/index_patterns/_fields_for_wildcard?pattern={title}&meta_fields=_source&meta_fields=_id&meta_fields=_type&meta_fields=_index&meta_fields=_score"
+        url = f"{BASE_URL}/api/index_patterns/_fields_for_wildcard"
 
+    # Only `pattern` is passed. Do NOT send `meta_fields` — this OSD version's
+    # route validation rejects the repeated meta_fields query params with a 400
+    # ("[request query.params]: definition for this key is missing"). requests
+    # URL-encodes the pattern's wildcard/special chars via the params dict.
     try:
         resp = requests.get(
             url, auth=(USERNAME, PASSWORD),
             headers={"Content-Type": "application/json", "osd-xsrf": "true"},
+            params={"pattern": title},
             verify=False, timeout=30,
         )
         if resp.status_code != 200:

--- a/charts/observability-stack/files/init-opensearch-dashboards.py
+++ b/charts/observability-stack/files/init-opensearch-dashboards.py
@@ -1964,7 +1964,7 @@ def refresh_index_pattern_fields(workspace_id, pattern_id, title):
         return False
 
 
-def delayed_field_refresh(workspace_id, patterns, max_attempts=12, interval_minutes=5):
+def delayed_field_refresh(workspace_id, titles, max_attempts=12, interval_minutes=5):
     """Periodically refresh field lists until every pattern is populated.
 
     main() warms the field lists immediately, but indices that are still empty
@@ -1973,11 +1973,17 @@ def delayed_field_refresh(workspace_id, patterns, max_attempts=12, interval_minu
     wait, poll on an interval and retry only the patterns that haven't been
     populated yet, stopping early once they all succeed. With the defaults this
     covers a one-hour window (12 attempts × 5 minutes).
+
+    Patterns are resolved by title on every attempt rather than once up front,
+    so this self-heals regardless of start order: if the backstop starts before
+    main() has created the index patterns, the early attempts simply find
+    nothing and retry until the patterns exist. This is what lets the compose
+    service / k8s Job run without a hard `depends_on` the init step — a
+    dependency that otherwise breaks `docker compose up --wait` (a
+    `service_completed_successfully` target exiting mid-startup makes --wait
+    abort with a non-zero code).
     """
-    pending = [(pid, title) for pid, title in patterns if pid]
-    if not pending:
-        print("⏭️  No index patterns to refresh")
-        return
+    pending = list(titles)
 
     print(
         f"\n⏳ Will refresh field lists as indices populate "
@@ -1986,9 +1992,14 @@ def delayed_field_refresh(workspace_id, patterns, max_attempts=12, interval_minu
     for attempt in range(1, max_attempts + 1):
         print(f"🔄 Field refresh attempt {attempt}/{max_attempts} ({len(pending)} pending)...")
         still_pending = []
-        for pattern_id, title in pending:
+        for title in pending:
+            pattern_id = get_existing_index_pattern(workspace_id, title)
+            if not pattern_id:
+                # Pattern not created yet (backstop outran init) — retry later.
+                still_pending.append(title)
+                continue
             if not refresh_index_pattern_fields(workspace_id, pattern_id, title):
-                still_pending.append((pattern_id, title))
+                still_pending.append(title)
         pending = still_pending
         if not pending:
             print("✅ Field refresh complete — all patterns populated")
@@ -2000,30 +2011,26 @@ def delayed_field_refresh(workspace_id, patterns, max_attempts=12, interval_minu
 
     print(
         f"⚠️  Field refresh finished with {len(pending)} pattern(s) still empty: "
-        f"{', '.join(title for _, title in pending)}"
+        f"{', '.join(pending)}"
     )
 
 
 def run_field_refresh_backstop():
-    """Re-read workspace + pattern IDs and run the delayed field-refresh loop.
+    """Run the delayed field-refresh loop as a standalone process.
 
     Split out from main() so it can run as a separate, long-running process
     (its own compose service / Kubernetes Job). main() is the fast, blocking
     setup that a Helm post-install/upgrade hook waits on; this backstop can run
     for up to an hour and must never block install/upgrade completion.
+
+    Intentionally has no hard ordering dependency on the init step: it waits for
+    dashboards, then delayed_field_refresh() resolves pattern IDs by title on
+    each attempt, so it works whether it starts before or after init.
     """
     wait_for_dashboards()
     workspace_id = get_existing_workspace()
-    logs_id = get_existing_index_pattern(workspace_id, "logs-otel-v1*")
-    traces_id = get_existing_index_pattern(workspace_id, "otel-v1-apm-span*")
-    svc_map_id = get_existing_index_pattern(workspace_id, "otel-v2-apm-service-map*")
-
-    patterns = [
-        (logs_id, "logs-otel-v1*"),
-        (traces_id, "otel-v1-apm-span*"),
-        (svc_map_id, "otel-v2-apm-service-map*"),
-    ]
-    delayed_field_refresh(workspace_id, patterns)
+    titles = ["logs-otel-v1*", "otel-v1-apm-span*", "otel-v2-apm-service-map*"]
+    delayed_field_refresh(workspace_id, titles)
 
 
 if __name__ == "__main__":

--- a/charts/observability-stack/files/init-opensearch-dashboards.py
+++ b/charts/observability-stack/files/init-opensearch-dashboards.py
@@ -1835,6 +1835,22 @@ def main():
 
     print("📊 Created index patterns for spans, logs, and service map")
 
+    # Warm the field list immediately after creation. Patterns created via the
+    # raw saved-objects API land with an empty `fields` attribute (OSD only
+    # fetches fields lazily on first Discover/Explore visit, and the on-read
+    # auto-fetch safety net was removed upstream). Without this, pre-generated
+    # datasets show "Fields (0)" and charts error with "Could not locate that
+    # index-pattern-field" until a manual refresh. This mirrors what the
+    # dataset-creation wizard does (pre-fetch _fields_for_wildcard at create
+    # time). delayed_field_refresh() below remains the backstop for indices
+    # that are still empty at init time.
+    for pid, title in (
+        (logs_pattern_id, "logs-otel-v1*"),
+        (traces_pattern_id, "otel-v1-apm-span*"),
+        (service_map_pattern_id, "otel-v2-apm-service-map*"),
+    ):
+        refresh_index_pattern_fields(workspace_id, pid, title)
+
     # Set logs as the default index pattern
     if logs_pattern_id:
         set_default_index_pattern(workspace_id, logs_pattern_id)
@@ -1948,27 +1964,55 @@ def refresh_index_pattern_fields(workspace_id, pattern_id, title):
         return False
 
 
-def delayed_field_refresh(workspace_id, patterns):
-    """Wait for data to land in indices, then refresh field lists.
+def delayed_field_refresh(workspace_id, patterns, max_attempts=12, interval_minutes=5):
+    """Periodically refresh field lists until every pattern is populated.
 
-    Called after the main init completes. Waits 10 minutes for the otel-demo
-    and agent examples to populate indices with representative documents so
-    the field refresh picks up all mapped fields.
+    main() warms the field lists immediately, but indices that are still empty
+    at init time (otel-demo and agent examples take a while to send their first
+    documents) return no fields on that first pass. Rather than a single blind
+    wait, poll on an interval and retry only the patterns that haven't been
+    populated yet, stopping early once they all succeed. With the defaults this
+    covers a one-hour window (12 attempts × 5 minutes).
     """
-    delay_minutes = 10
-    print(f"\n⏳ Waiting {delay_minutes} minutes for indices to populate before refreshing fields...")
-    time.sleep(delay_minutes * 60)
+    pending = [(pid, title) for pid, title in patterns if pid]
+    if not pending:
+        print("⏭️  No index patterns to refresh")
+        return
 
-    print("🔄 Refreshing index pattern field lists...")
-    for pattern_id, title in patterns:
-        refresh_index_pattern_fields(workspace_id, pattern_id, title)
-    print("✅ Field refresh complete")
+    print(
+        f"\n⏳ Will refresh field lists as indices populate "
+        f"(up to {max_attempts} attempts every {interval_minutes} min)..."
+    )
+    for attempt in range(1, max_attempts + 1):
+        print(f"🔄 Field refresh attempt {attempt}/{max_attempts} ({len(pending)} pending)...")
+        still_pending = []
+        for pattern_id, title in pending:
+            if not refresh_index_pattern_fields(workspace_id, pattern_id, title):
+                still_pending.append((pattern_id, title))
+        pending = still_pending
+        if not pending:
+            print("✅ Field refresh complete — all patterns populated")
+            return
+        # Sleep between attempts (not before the first / after the last), so a
+        # stack whose indices are already populated exits promptly.
+        if attempt < max_attempts:
+            time.sleep(interval_minutes * 60)
+
+    print(
+        f"⚠️  Field refresh finished with {len(pending)} pattern(s) still empty: "
+        f"{', '.join(title for _, title in pending)}"
+    )
 
 
-if __name__ == "__main__":
-    main()
+def run_field_refresh_backstop():
+    """Re-read workspace + pattern IDs and run the delayed field-refresh loop.
 
-    # Re-read workspace and pattern IDs for the delayed refresh.
+    Split out from main() so it can run as a separate, long-running process
+    (its own compose service / Kubernetes Job). main() is the fast, blocking
+    setup that a Helm post-install/upgrade hook waits on; this backstop can run
+    for up to an hour and must never block install/upgrade completion.
+    """
+    wait_for_dashboards()
     workspace_id = get_existing_workspace()
     logs_id = get_existing_index_pattern(workspace_id, "logs-otel-v1*")
     traces_id = get_existing_index_pattern(workspace_id, "otel-v1-apm-span*")
@@ -1980,3 +2024,17 @@ if __name__ == "__main__":
         (svc_map_id, "otel-v2-apm-service-map*"),
     ]
     delayed_field_refresh(workspace_id, patterns)
+
+
+if __name__ == "__main__":
+    import sys
+
+    # Two modes, run as separate processes so the long-running field-refresh
+    # backstop never blocks init completion (or a Helm hook):
+    #   (default)      → main(): fast one-shot setup + immediate field warm
+    #   refresh-loop   → periodic field refresh until indices populate
+    mode = sys.argv[1] if len(sys.argv) > 1 else "init"
+    if mode == "refresh-loop":
+        run_field_refresh_backstop()
+    else:
+        main()

--- a/charts/observability-stack/templates/field-refresh-configmap.yaml
+++ b/charts/observability-stack/templates/field-refresh-configmap.yaml
@@ -1,0 +1,16 @@
+{{- if index .Values "opensearch-dashboards" "enabled" }}
+# Dedicated, non-hook copy of the init script for the field-refresh backstop
+# Job. Kept separate from the hook-managed init-script ConfigMap so the
+# non-hook Job has no ordering/delete-recreate coupling with the post-install
+# hook phase. The refresh-loop mode only calls the OpenSearch Dashboards API,
+# so only the Python script is needed here (no /config assets).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "observability-stack.fullname" . }}-field-refresh-script
+  labels:
+    {{- include "observability-stack.labels" . | nindent 4 }}
+data:
+  init-opensearch-dashboards.py: |
+{{ .Files.Get "files/init-opensearch-dashboards.py" | indent 4 }}
+{{- end }}

--- a/charts/observability-stack/templates/field-refresh-job.yaml
+++ b/charts/observability-stack/templates/field-refresh-job.yaml
@@ -1,0 +1,59 @@
+{{- if index .Values "opensearch-dashboards" "enabled" }}
+# Field-refresh backstop - populates index-pattern field lists as indices fill
+# with data. Deliberately NOT a Helm hook: it can run for up to ~1 hour and must
+# never block install/upgrade completion. The fast one-shot setup lives in the
+# init-dashboards hook Job, which Helm waits on; this Job runs independently and
+# refreshes field lists once telemetry lands in otherwise-empty indices.
+#
+# Job spec.template is immutable, so a plain `helm upgrade` cannot patch an
+# existing Job. The name is suffixed with the release revision so each upgrade
+# creates a fresh Job instead; ttlSecondsAfterFinished reaps completed ones.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "observability-stack.fullname" . }}-field-refresh-{{ .Release.Revision }}
+  labels:
+    {{- include "observability-stack.labels" . | nindent 4 }}
+spec:
+  backoffLimit: 3
+  # Cap total runtime so a stuck Job cannot linger indefinitely. Matches the
+  # script's default loop window (12 attempts x 5 min) plus setup slack.
+  activeDeadlineSeconds: 4200
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: field-refresh
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: field-refresh
+          image: python:3.12-slim
+          command:
+            - /bin/sh
+            - -c
+            - |
+              pip install -q requests pyyaml && python -u /scripts/init-opensearch-dashboards.py refresh-loop
+          env:
+            - name: OPENSEARCH_USER
+              valueFrom:
+                secretKeyRef:
+                  name: opensearch-credentials
+                  key: username
+            - name: OPENSEARCH_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: opensearch-credentials
+                  key: password
+            - name: BASE_URL
+              value: "http://{{ .Release.Name }}-opensearch-dashboards:5601"
+            - name: OPENSEARCH_ENDPOINT
+              value: "https://{{ .Values.opensearchServiceName | default "opensearch-cluster-master" }}:9200"
+          volumeMounts:
+            - name: field-refresh-script
+              mountPath: /scripts
+      volumes:
+        - name: field-refresh-script
+          configMap:
+            name: {{ include "observability-stack.fullname" . }}-field-refresh-script
+{{- end }}

--- a/charts/observability-stack/templates/init-dashboards-job.yaml
+++ b/charts/observability-stack/templates/init-dashboards-job.yaml
@@ -24,7 +24,7 @@ spec:
             - /bin/sh
             - -c
             - |
-              pip install -q requests pyyaml && python /scripts/init-opensearch-dashboards.py
+              pip install -q requests pyyaml && python -u /scripts/init-opensearch-dashboards.py
           env:
             - name: OPENSEARCH_USER
               valueFrom:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -272,7 +272,7 @@ services:
   opensearch-dashboards-init:
     image: python:3.11-alpine
     container_name: opensearch-dashboards-init
-    command: sh -c "pip install requests pyyaml && python /init.py"
+    command: sh -c "pip install requests pyyaml && python -u /init.py"
     environment:
       - OPENSEARCH_USER=${OPENSEARCH_USER}
       - OPENSEARCH_PASSWORD=${OPENSEARCH_PASSWORD}
@@ -306,6 +306,31 @@ services:
       - ./docker-compose/opensearch-dashboards/dashboard-pipeline-health.yaml:/config/dashboard-pipeline-health.yaml
       - ./docker-compose/opensearch-dashboards/init/architecture.png:/config/architecture.png
       - ./docker-compose/opensearch-dashboards/init/dashboard-astronomy-shop.ndjson:/config/dashboard-astronomy-shop.ndjson
+    networks:
+      - observability-stack-network
+    restart: "no"
+    logging: *logging
+
+  # Field-refresh backstop - populates index-pattern field lists as indices
+  # fill with data. Runs as a separate long-lived process (up to ~1 hour) so it
+  # never blocks the one-shot init above. Index patterns created on a fresh
+  # stack start empty because their indices have no documents yet; this loop
+  # refreshes them once telemetry lands.
+  opensearch-dashboards-field-refresh:
+    image: python:3.11-alpine
+    container_name: opensearch-dashboards-field-refresh
+    command: sh -c "pip install requests pyyaml && python -u /init.py refresh-loop"
+    environment:
+      - OPENSEARCH_USER=${OPENSEARCH_USER}
+      - OPENSEARCH_PASSWORD=${OPENSEARCH_PASSWORD}
+      - OPENSEARCH_DASHBOARDS_HOST=${OPENSEARCH_DASHBOARDS_HOST}
+      - OPENSEARCH_DASHBOARDS_PORT=${OPENSEARCH_DASHBOARDS_PORT}
+      - OPENSEARCH_DASHBOARDS_PROTOCOL=${OPENSEARCH_DASHBOARDS_PROTOCOL}
+    volumes:
+      - ./docker-compose/opensearch-dashboards/init/init-opensearch-dashboards.py:/init.py
+    depends_on:
+      opensearch-dashboards-init:
+        condition: service_completed_successfully
     networks:
       - observability-stack-network
     restart: "no"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -328,9 +328,12 @@ services:
       - OPENSEARCH_DASHBOARDS_PROTOCOL=${OPENSEARCH_DASHBOARDS_PROTOCOL}
     volumes:
       - ./docker-compose/opensearch-dashboards/init/init-opensearch-dashboards.py:/init.py
-    depends_on:
-      opensearch-dashboards-init:
-        condition: service_completed_successfully
+    # No `depends_on` the init service on purpose. A
+    # `service_completed_successfully` dependency on a one-shot that exits
+    # mid-startup makes `docker compose up --wait` (test/e2e.sh) abort with a
+    # non-zero code. The refresh loop instead waits for dashboards itself and
+    # resolves index-pattern IDs by title on each attempt, so it self-heals
+    # whether it starts before or after init.
     networks:
       - observability-stack-network
     restart: "no"

--- a/docker-compose/opensearch-dashboards/init/init-opensearch-dashboards.py
+++ b/docker-compose/opensearch-dashboards/init/init-opensearch-dashboards.py
@@ -1761,6 +1761,22 @@ def main():
 
     print("📊 Created index patterns for spans, logs, and service map")
 
+    # Warm the field list immediately after creation. Patterns created via the
+    # raw saved-objects API land with an empty `fields` attribute (OSD only
+    # fetches fields lazily on first Discover/Explore visit, and the on-read
+    # auto-fetch safety net was removed upstream). Without this, pre-generated
+    # datasets show "Fields (0)" and charts error with "Could not locate that
+    # index-pattern-field" until a manual refresh. This mirrors what the
+    # dataset-creation wizard does (pre-fetch _fields_for_wildcard at create
+    # time). delayed_field_refresh() below remains the backstop for indices
+    # that are still empty at init time.
+    for pid, title in (
+        (logs_pattern_id, "logs-otel-v1*"),
+        (traces_pattern_id, "otel-v1-apm-span*"),
+        (service_map_pattern_id, "otel-v2-apm-service-map*"),
+    ):
+        refresh_index_pattern_fields(workspace_id, pid, title)
+
     # Set logs as the default index pattern
     if logs_pattern_id:
         set_default_index_pattern(workspace_id, logs_pattern_id)
@@ -1875,28 +1891,55 @@ def refresh_index_pattern_fields(workspace_id, pattern_id, title):
         return False
 
 
-def delayed_field_refresh(workspace_id, patterns):
-    """Wait for data to land in indices, then refresh field lists.
+def delayed_field_refresh(workspace_id, patterns, max_attempts=12, interval_minutes=5):
+    """Periodically refresh field lists until every pattern is populated.
 
-    Called after the main init completes. Waits 10 minutes for the otel-demo
-    and agent examples to populate indices with representative documents so
-    the field refresh picks up all mapped fields.
+    main() warms the field lists immediately, but indices that are still empty
+    at init time (otel-demo and agent examples take a while to send their first
+    documents) return no fields on that first pass. Rather than a single blind
+    wait, poll on an interval and retry only the patterns that haven't been
+    populated yet, stopping early once they all succeed. With the defaults this
+    covers a one-hour window (12 attempts × 5 minutes).
     """
-    delay_minutes = 10
-    print(f"\n⏳ Waiting {delay_minutes} minutes for indices to populate before refreshing fields...")
-    time.sleep(delay_minutes * 60)
+    pending = [(pid, title) for pid, title in patterns if pid]
+    if not pending:
+        print("⏭️  No index patterns to refresh")
+        return
 
-    print("🔄 Refreshing index pattern field lists...")
-    for pattern_id, title in patterns:
-        refresh_index_pattern_fields(workspace_id, pattern_id, title)
-    print("✅ Field refresh complete")
+    print(
+        f"\n⏳ Will refresh field lists as indices populate "
+        f"(up to {max_attempts} attempts every {interval_minutes} min)..."
+    )
+    for attempt in range(1, max_attempts + 1):
+        print(f"🔄 Field refresh attempt {attempt}/{max_attempts} ({len(pending)} pending)...")
+        still_pending = []
+        for pattern_id, title in pending:
+            if not refresh_index_pattern_fields(workspace_id, pattern_id, title):
+                still_pending.append((pattern_id, title))
+        pending = still_pending
+        if not pending:
+            print("✅ Field refresh complete — all patterns populated")
+            return
+        # Sleep between attempts (not before the first / after the last), so a
+        # stack whose indices are already populated exits promptly.
+        if attempt < max_attempts:
+            time.sleep(interval_minutes * 60)
+
+    print(
+        f"⚠️  Field refresh finished with {len(pending)} pattern(s) still empty: "
+        f"{', '.join(title for _, title in pending)}"
+    )
 
 
-if __name__ == "__main__":
-    main()
+def run_field_refresh_backstop():
+    """Re-read workspace + pattern IDs and run the delayed field-refresh loop.
 
-    # Re-read workspace and pattern IDs for the delayed refresh.
-    # main() already printed success, so this is a background follow-up.
+    Split out from main() so it can run as a separate, long-running process
+    (its own compose service / Kubernetes Job). main() is the fast, blocking
+    setup that a Helm post-install/upgrade hook waits on; this backstop can run
+    for up to an hour and must never block install/upgrade completion.
+    """
+    wait_for_dashboards()
     workspace_id = get_existing_workspace()
     logs_id = get_existing_index_pattern(workspace_id, "logs-otel-v1*")
     traces_id = get_existing_index_pattern(workspace_id, "otel-v1-apm-span*")
@@ -1908,3 +1951,17 @@ if __name__ == "__main__":
         (svc_map_id, "otel-v2-apm-service-map*"),
     ]
     delayed_field_refresh(workspace_id, patterns)
+
+
+if __name__ == "__main__":
+    import sys
+
+    # Two modes, run as separate processes so the long-running field-refresh
+    # backstop never blocks init completion (or a Helm hook):
+    #   (default)      → main(): fast one-shot setup + immediate field warm
+    #   refresh-loop   → periodic field refresh until indices populate
+    mode = sys.argv[1] if len(sys.argv) > 1 else "init"
+    if mode == "refresh-loop":
+        run_field_refresh_backstop()
+    else:
+        main()

--- a/docker-compose/opensearch-dashboards/init/init-opensearch-dashboards.py
+++ b/docker-compose/opensearch-dashboards/init/init-opensearch-dashboards.py
@@ -1847,14 +1847,19 @@ def refresh_index_pattern_fields(workspace_id, pattern_id, title):
         return False
 
     if workspace_id and workspace_id != "default":
-        url = f"{BASE_URL}/w/{workspace_id}/api/index_patterns/_fields_for_wildcard?pattern={title}&meta_fields=_source&meta_fields=_id&meta_fields=_type&meta_fields=_index&meta_fields=_score"
+        url = f"{BASE_URL}/w/{workspace_id}/api/index_patterns/_fields_for_wildcard"
     else:
-        url = f"{BASE_URL}/api/index_patterns/_fields_for_wildcard?pattern={title}&meta_fields=_source&meta_fields=_id&meta_fields=_type&meta_fields=_index&meta_fields=_score"
+        url = f"{BASE_URL}/api/index_patterns/_fields_for_wildcard"
 
+    # Only `pattern` is passed. Do NOT send `meta_fields` — this OSD version's
+    # route validation rejects the repeated meta_fields query params with a 400
+    # ("[request query.params]: definition for this key is missing"). requests
+    # URL-encodes the pattern's wildcard/special chars via the params dict.
     try:
         resp = requests.get(
             url, auth=(USERNAME, PASSWORD),
             headers={"Content-Type": "application/json", "osd-xsrf": "true"},
+            params={"pattern": title},
             verify=False, timeout=30,
         )
         if resp.status_code != 200:

--- a/docker-compose/opensearch-dashboards/init/init-opensearch-dashboards.py
+++ b/docker-compose/opensearch-dashboards/init/init-opensearch-dashboards.py
@@ -1891,7 +1891,7 @@ def refresh_index_pattern_fields(workspace_id, pattern_id, title):
         return False
 
 
-def delayed_field_refresh(workspace_id, patterns, max_attempts=12, interval_minutes=5):
+def delayed_field_refresh(workspace_id, titles, max_attempts=12, interval_minutes=5):
     """Periodically refresh field lists until every pattern is populated.
 
     main() warms the field lists immediately, but indices that are still empty
@@ -1900,11 +1900,17 @@ def delayed_field_refresh(workspace_id, patterns, max_attempts=12, interval_minu
     wait, poll on an interval and retry only the patterns that haven't been
     populated yet, stopping early once they all succeed. With the defaults this
     covers a one-hour window (12 attempts × 5 minutes).
+
+    Patterns are resolved by title on every attempt rather than once up front,
+    so this self-heals regardless of start order: if the backstop starts before
+    main() has created the index patterns, the early attempts simply find
+    nothing and retry until the patterns exist. This is what lets the compose
+    service / k8s Job run without a hard `depends_on` the init step — a
+    dependency that otherwise breaks `docker compose up --wait` (a
+    `service_completed_successfully` target exiting mid-startup makes --wait
+    abort with a non-zero code).
     """
-    pending = [(pid, title) for pid, title in patterns if pid]
-    if not pending:
-        print("⏭️  No index patterns to refresh")
-        return
+    pending = list(titles)
 
     print(
         f"\n⏳ Will refresh field lists as indices populate "
@@ -1913,9 +1919,14 @@ def delayed_field_refresh(workspace_id, patterns, max_attempts=12, interval_minu
     for attempt in range(1, max_attempts + 1):
         print(f"🔄 Field refresh attempt {attempt}/{max_attempts} ({len(pending)} pending)...")
         still_pending = []
-        for pattern_id, title in pending:
+        for title in pending:
+            pattern_id = get_existing_index_pattern(workspace_id, title)
+            if not pattern_id:
+                # Pattern not created yet (backstop outran init) — retry later.
+                still_pending.append(title)
+                continue
             if not refresh_index_pattern_fields(workspace_id, pattern_id, title):
-                still_pending.append((pattern_id, title))
+                still_pending.append(title)
         pending = still_pending
         if not pending:
             print("✅ Field refresh complete — all patterns populated")
@@ -1927,30 +1938,26 @@ def delayed_field_refresh(workspace_id, patterns, max_attempts=12, interval_minu
 
     print(
         f"⚠️  Field refresh finished with {len(pending)} pattern(s) still empty: "
-        f"{', '.join(title for _, title in pending)}"
+        f"{', '.join(pending)}"
     )
 
 
 def run_field_refresh_backstop():
-    """Re-read workspace + pattern IDs and run the delayed field-refresh loop.
+    """Run the delayed field-refresh loop as a standalone process.
 
     Split out from main() so it can run as a separate, long-running process
     (its own compose service / Kubernetes Job). main() is the fast, blocking
     setup that a Helm post-install/upgrade hook waits on; this backstop can run
     for up to an hour and must never block install/upgrade completion.
+
+    Intentionally has no hard ordering dependency on the init step: it waits for
+    dashboards, then delayed_field_refresh() resolves pattern IDs by title on
+    each attempt, so it works whether it starts before or after init.
     """
     wait_for_dashboards()
     workspace_id = get_existing_workspace()
-    logs_id = get_existing_index_pattern(workspace_id, "logs-otel-v1*")
-    traces_id = get_existing_index_pattern(workspace_id, "otel-v1-apm-span*")
-    svc_map_id = get_existing_index_pattern(workspace_id, "otel-v2-apm-service-map*")
-
-    patterns = [
-        (logs_id, "logs-otel-v1*"),
-        (traces_id, "otel-v1-apm-span*"),
-        (svc_map_id, "otel-v2-apm-service-map*"),
-    ]
-    delayed_field_refresh(workspace_id, patterns)
+    titles = ["logs-otel-v1*", "otel-v1-apm-span*", "otel-v2-apm-service-map*"]
+    delayed_field_refresh(workspace_id, titles)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Pre-generated index patterns (`logs-otel-v1*`, `otel-v1-apm-span*`, `otel-v2-apm-service-map*`) were being created by the Dashboards initialization script with an empty `fields` attribute. In the UI this appeared as **"Fields (0)"**, and visualizations failed with errors such as:

> Could not locate that index-pattern-field (id: endTime)

Recreating the dataset through the UI repaired the issue because the dataset creation flow populates the field list, but the pre-generated index patterns created during stack initialization remained permanently broken.

This PR populates index pattern fields during initialization and refactors the delayed refresh into a separate background process so it never blocks stack startup or Helm install/upgrade operations.

---

## Root cause

Two issues combined to produce the bug.

### 1. The initialization script never populated fields at creation time

The script creates index patterns directly through the Saved Objects API:

```http
POST /api/saved_objects/index-pattern
```

Unlike the dataset creation wizard, this code path never performs a `_fields_for_wildcard` request, so the saved object is persisted with an empty `fields` attribute.

OpenSearch Dashboards previously compensated by lazily fetching fields on first use, but that behavior was removed upstream in **OpenSearch-Dashboards#11653**. **PR #12236** restored field prefetching for datasets created through the UI wizard, but pre-generated index patterns created out-of-band still bypass that logic.

### 2. The `_fields_for_wildcard` refresh call itself was broken

The existing `refresh_index_pattern_fields()` implementation passed repeated `meta_fields` query parameters:

```text
meta_fields=_source
meta_fields=_id
...
```

This version of OpenSearch Dashboards rejects those parameters with a `400` response (`definition for this key is missing`), so even when the refresh function executed, it silently failed and never populated any fields.

The fix removes the unnecessary `meta_fields` parameters entirely and sends only the `pattern` parameter using `requests`' `params` dictionary for proper URL encoding.

---

## Changes

### 1. Fix the `_fields_for_wildcard` API call

Updated `refresh_index_pattern_fields()` to:

- Remove the unsupported `meta_fields` query parameters.
- Send only the `pattern` parameter.
- Use `requests`' `params` dictionary for proper URL encoding.

This restores compatibility with current OpenSearch Dashboards versions.

---

### 2. Populate fields immediately after creation

After each index pattern is created, `main()` now immediately invokes `refresh_index_pattern_fields()`, mirroring the behavior of the dataset creation wizard:

- Fetch fields via `_fields_for_wildcard`
- Persist the populated field list back into the saved object

This fixes environments where matching indices already exist.

---

### 3. Replace the delayed refresh with a bounded retry loop

On a fresh deployment, matching indices often exist before any documents have been indexed, so the initial refresh legitimately returns no fields.

Previously the script:

- Slept for 10 minutes.
- Retried once.
- Silently gave up if fields were still unavailable.

This has been replaced with a bounded retry loop that:

- Performs up to **12 attempts**
- Waits **5 minutes** between attempts
- Runs for approximately **1 hour** maximum
- Retries only index patterns that are still empty
- Exits immediately once every pattern has been populated
- Resolves index-pattern IDs by title on each attempt, making the process resilient regardless of startup ordering

The first refresh occurs immediately, so environments that already contain data complete within seconds.

---

### 4. Run the retry loop outside the initialization hook

The initialization script runs as a Helm `post-install` / `post-upgrade` hook, and Helm waits for hook Jobs to complete before finishing an install or upgrade.

Running an hour-long retry loop inside that hook would unnecessarily block every deployment.

The script now supports two execution modes:

- **Default (`main`)**
  - Performs the normal initialization
  - Fast one-shot execution
  - Used by the existing Helm hook

- **`refresh-loop`**
  - Runs only the bounded field refresh retry loop
  - Executes independently of the initialization hook

#### Docker Compose

Added a new service:

- `opensearch-dashboards-field-refresh`

Unlike the previous implementation, it intentionally **does not** depend on the initialization container completing successfully. A `service_completed_successfully` dependency on a one-shot container causes `docker compose up --wait` (used by `test/e2e.sh`) to exit non-zero when the init container finishes.

Instead, the refresh loop:

- Waits for Dashboards to become available.
- Resolves index-pattern IDs by title on each retry.
- Works correctly whether it starts before or after the initialization container.

#### Helm

Added:

- `field-refresh-job.yaml`
- `field-refresh-configmap.yaml`

The refresh Job is intentionally **not** a Helm hook so it does not delay installs or upgrades.

Additional implementation details:

- Job name is suffixed with `.Release.Revision` to avoid Job `spec.template` immutability during upgrades.
- Uses a dedicated ConfigMap because the existing initialization ConfigMap is itself a hook resource and cannot reliably be mounted by a non-hook Job.
- Adds `activeDeadlineSeconds` and `ttlSecondsAfterFinished` for automatic cleanup.

---

### 5. Enable unbuffered logging

All Python invocations now use:

```bash
python -u
```

This applies to:

- Docker Compose initialization
- Docker Compose field refresh
- Helm initialization Job

Previously Python buffered stdout until process exit, making the initialization flow difficult to monitor and debug.

---

## Testing

Verified with a clean Docker Compose deployment:

```bash
docker compose down -v
docker compose up -d
```

Results:

- `opensearch-dashboards-init` executes `main()` and exits successfully.
- `opensearch-dashboards-field-refresh` starts independently.
- All three index patterns are populated on the first retry:
  - `logs-otel-v1*` → **135 fields**
  - `otel-v1-apm-span*` → **280 fields**
  - `otel-v2-apm-service-map*` → **13 fields**
- Background refresh completes in approximately **10 seconds**.
- Ran `test/e2e.sh` end-to-end locally; all checks passed (`EXIT 0`).
- `helm template` renders both Jobs, both ConfigMaps, correct hook/non-hook annotations, correct command arguments, deadlines, and unbuffered Python execution.
- Both Python scripts compile successfully.
- `docker compose config` validates.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
