### PR TITLE
docs: enable PPL Query Builder by default, remove enablement docs

### DIFF
--- a/docs/starlight-docs/src/content/docs/investigate/discover-logs.md
+++ b/docs/starlight-docs/src/content/docs/investigate/discover-logs.md
@@ -73,13 +73,13 @@ You can combine multiple conditions by providing several `WHERE` clauses:
 
 ### Building queries without PPL
 
-With the PPL Query Builder enabled, a new logs query opens in a visual builder instead of the PPL editor. You pick fields, values, aggregations, and a sort from menus, and the builder compiles the PPL.
+With the PPL Query Builder, a new logs query opens in a visual builder instead of the PPL editor. You pick fields, values, aggregations, and a sort from menus, and the builder compiles the PPL.
 
 ![PPL Query Builder on the Logs page, with a Where filter, a Count aggregation, an hourly time bucket, and the aggregation menu open](/docs/images/ppl/ppl-query-builder.png)
 
 The **Code** / **Builder** toggle at the upper right of the query panel switches between the visual builder and the PPL editor, so you can read and hand-edit the generated query at any point.
 
-See [PPL Query Builder](/docs/ppl/query-builder/) for the controls it offers and how to enable it.
+See [PPL Query Builder](/docs/ppl/query-builder/) for the controls it offers.
 
 ### Managing queries
 

--- a/docs/starlight-docs/src/content/docs/ppl/query-builder.md
+++ b/docs/starlight-docs/src/content/docs/ppl/query-builder.md
@@ -9,10 +9,6 @@ It covers a subset of PPL: search, filter, aggregate, and sort. For anything out
 
 ![PPL Query Builder on the Logs page, with a Where filter, a Count aggregation, an hourly time bucket, and the aggregation menu open](/docs/images/ppl/ppl-query-builder.png)
 
-:::note[Availability]
-The query builder ships in OpenSearch Dashboards 3.8.0, switched off by default. Set `explore.logsQueryBuilder.enabled: true` in `opensearch_dashboards.yml` to turn it on. See [Enabling the builder](#enabling-the-builder).
-:::
-
 ## Builder mode and Code mode
 
 You edit a logs query in one of two modes. The **Code** / **Builder** toggle at the upper right of the query panel switches between them.
@@ -102,17 +98,6 @@ generates:
 ```
 
 Because the query aggregates, Discover Logs switches to the **Visualization** tab to chart the result.
-
-## Enabling the builder
-
-A server-side setting gates the builder. Add this to `opensearch_dashboards.yml`:
-
-```yaml
-explore.enabled: true
-explore.logsQueryBuilder.enabled: true
-```
-
-Restart OpenSearch Dashboards to apply the change. With the setting off, the Discover Logs page shows the standard PPL query panel.
 
 ## See also
 


### PR DESCRIPTION
### Description

Follow-up to #383. Enables the PPL Query Builder feature flag by default across the observability stack setup and removes the now-unnecessary enablement instructions from the docs.

**Enable the flag by default** — added `explore.logsQueryBuilder.enabled: true` to:
- `docker-compose/opensearch-dashboards/opensearch_dashboards.template.yml`
- `charts/observability-stack/values.yaml`
- `charts/observability-stack/values-anonymous-auth.yaml`

These configs already set `explore.enabled: true`, so the builder is now on out of the box.

**Docs cleanup** — since the builder ships enabled by default in this stack:
- Removed the `## Enabling the builder` section from `ppl/query-builder.md`
- Removed the `:::note[Availability]` block that told users to flip the flag (and its now-dangling `#enabling-the-builder` anchor link)
- Dropped the "and how to enable it" reference and reworded the conditional "With the PPL Query Builder enabled" phrasing on `investigate/discover-logs.md`

### Testing

- Ran the Starlight docs build (`npm run build`). The link validator reports the same 41 pre-existing invalid links (16 files) on both `main` and this branch — this change introduces no new broken links, and specifically leaves no dangling `#enabling-the-builder` anchor.
- Validated YAML syntax of all three modified config files.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.