### PR TITLE
docs: redirect old PPL Query Builder page to Discover Logs

### DIFF
--- a/docs/starlight-docs/astro.config.mjs
+++ b/docs/starlight-docs/astro.config.mjs
@@ -16,6 +16,7 @@ export default defineConfig({
 	},
 	redirects: {
 		'/get-started': '/get-started/installation/',
+		'/ppl/query-builder': '/investigate/discover-logs/#building-queries-with-the-ppl-query-builder',
 		'/sdks/python': '/send-data/ai-agents/python/',
 		'/sdks/javascript': '/send-data/ai-agents/typescript/',
 		'/sdks/python-experiments': '/agent-evals/evaluation/',


### PR DESCRIPTION
### Description

Follow-up to #390. That PR merged the standalone **PPL Query Builder** page into the **Discover Logs** page and removed `docs/starlight-docs/src/content/docs/ppl/query-builder.md`, which broke the previously-shared link `https://observability.opensearch.org/docs/ppl/query-builder/` (now 404).

This adds a redirect so the old URL points to the new in-page section:

```
/ppl/query-builder → /investigate/discover-logs/#building-queries-with-the-ppl-query-builder
```

The redirect follows the same pattern as the existing entries in `astro.config.mjs`'s `redirects` block.

### Verification

- Ran `npm run build` — completed successfully and the link validator reports **all internal links are valid**.
- Confirmed the generated redirect page `dist/ppl/query-builder/index.html` emits:
  ```html
  <meta http-equiv="refresh" content="0;url=/investigate/discover-logs/#building-queries-with-the-ppl-query-builder">
  ```
- Confirmed the target anchor `## Building queries with the PPL Query Builder` exists on the Discover Logs page.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.