### PR TITLE
feat(dashboards): enable PPL query linter (queryEnhancements.ppl.lint.enabled)

### DIFF
--- a/charts/observability-stack/values-anonymous-auth.yaml
+++ b/charts/observability-stack/values-anonymous-auth.yaml
@@ -180,6 +180,7 @@ opensearch-dashboards:
       explore.agentTraces.enabled: true
       explore.logsDrilldown.enabled: true
       explore.logsQueryBuilder.enabled: true
+      queryEnhancements.ppl.lint.enabled: true
       workspace.enabled: true
       data_source.enabled: true
       data_source.ssl.verificationMode: none

--- a/charts/observability-stack/values.yaml
+++ b/charts/observability-stack/values.yaml
@@ -133,6 +133,7 @@ opensearch-dashboards:
       explore.agentTraces.enabled: true
       explore.logsDrilldown.enabled: true
       explore.logsQueryBuilder.enabled: true
+      queryEnhancements.ppl.lint.enabled: true
       workspace.enabled: true
       data_source.enabled: true
       data_source.ssl.verificationMode: none

--- a/docker-compose/opensearch-dashboards/opensearch_dashboards.template.yml
+++ b/docker-compose/opensearch-dashboards/opensearch_dashboards.template.yml
@@ -80,6 +80,10 @@ explore.discoverMetrics.enabled: true
 explore.agentTraces.enabled: true
 explore.logsDrilldown.enabled: true
 explore.logsQueryBuilder.enabled: true
+# PPL syntax linter in the query editor (Explore / PPL query builder). Ships in
+# OSD 3.8, off by default; the queryEnhancements plugin reads this via
+# DynamicConfigService, which falls back to this static value.
+queryEnhancements.ppl.lint.enabled: true
 # Surfaces the Alert Manager UI in the Observability plugin, backed by the
 # alertmanager.uri configured on the Prometheus datasource.
 observability.alertManager.enabled: true


### PR DESCRIPTION
## What

Enables the **PPL syntax linter** in the OpenSearch Dashboards query editor (Explore / PPL query builder) by adding `queryEnhancements.ppl.lint.enabled: true` to the OSD config.

## Why / verification

The flag ships in **OSD 3.8** and is **off by default** — verified against the 3.8.0 `queryEnhancements` config schema (`src/plugins/query_enhancements/common/config.ts`):
```ts
ppl: schema.object({
  lint: schema.object({ enabled: schema.boolean({ defaultValue: false }) }),
}),
```
The plugin resolves the capability (`queryEnhancements.pplLint`) via `DynamicConfigService`. With no external dynamic-config store configured (our case), the `DummyConfigStoreClient` returns nothing and the service **falls back to the static `opensearch_dashboards.yml` value** — so this setting takes effect. Confirmed live: after applying it, `POST /api/core/capabilities` returns `queryEnhancements: {"pplLint": true}`.

## Changes

Applied to all three OSD-config locations the repo keeps in sync:
- `charts/observability-stack/values.yaml`
- `charts/observability-stack/values-anonymous-auth.yaml` (the block that wins under anonymous auth)
- `docker-compose/opensearch-dashboards/opensearch_dashboards.template.yml`

AWS consumes the Helm chart, so it's covered transitively.

## Testing

- Verified on a live playground OSD (3.8.0): flag present in the running config; capabilities API reports `pplLint: true`; OSD starts clean with no config parse error.
- `helm lint` passes; `helm template` renders the flag into the OSD ConfigMap.