### PR TITLE
feat(aws): support optimized engine for managed OpenSearch domains

### DIFF
--- a/aws/cdk/bin/app.ts
+++ b/aws/cdk/bin/app.ts
@@ -12,15 +12,22 @@ const env = {
 };
 
 const opensearchType = (app.node.tryGetContext('opensearchType') as 'managed' | 'serverless') || 'managed';
+// Defaults to the optimized engine (OR2). Pass -c engineMode=general -c osInstanceType=r6g.large.search for a standard domain.
+const engineMode = ((app.node.tryGetContext('engineMode') as string) || 'optimized').toUpperCase() === 'GENERAL'
+  ? 'GENERAL'
+  : 'OPTIMIZED';
+const osInstanceType = (app.node.tryGetContext('osInstanceType') as string)
+  || (engineMode === 'OPTIMIZED' ? 'or2.large.search' : 'r6g.large.search');
 
 // Slow-changing infra: OpenSearch domain/collection, AMP workspace, DQS data source
 const infra = new InfraStack(app, 'ObsInfra', {
   env,
   opensearchType,
   ...(opensearchType !== 'serverless' && {
-    osInstanceType: 'r6g.large.search',
+    osInstanceType,
     osInstanceCount: 1,
     osVolumeSize: 100,
+    osEngineMode: engineMode,
   }),
 });
 

--- a/aws/cdk/lib/infra-stack.ts
+++ b/aws/cdk/lib/infra-stack.ts
@@ -9,6 +9,7 @@ export interface InfraStackProps extends cdk.StackProps {
   osInstanceType?: string;
   osInstanceCount?: number;
   osVolumeSize?: number;
+  osEngineMode?: 'GENERAL' | 'OPTIMIZED';
 }
 
 export class InfraStack extends cdk.Stack {
@@ -41,9 +42,10 @@ export class InfraStack extends cdk.Stack {
       this.pipelineRoleArn = serverless.pipelineRole.roleArn;
     } else {
       const opensearch = new OpenSearchConstruct(this, 'OpenSearch', {
-        instanceType: props.osInstanceType ?? 'r6g.large.search',
+        instanceType: props.osInstanceType ?? 'or2.large.search',
         instanceCount: props.osInstanceCount ?? 1,
         volumeSize: props.osVolumeSize ?? 100,
+        engineMode: props.osEngineMode ?? 'OPTIMIZED',
       });
 
       this.domainEndpoint = opensearch.domain.domainEndpoint;

--- a/aws/cdk/lib/opensearch.ts
+++ b/aws/cdk/lib/opensearch.ts
@@ -4,10 +4,20 @@ import * as iam from 'aws-cdk-lib/aws-iam';
 import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
 import { Construct } from 'constructs';
 
+// Optimized instance families. OR1/OR2/OM2 use gp3/io1 EBS; OI2 uses local NVMe.
+const OPTIMIZED_FAMILIES = ['or1', 'or2', 'om2', 'oi2'];
+const NVME_FAMILIES = ['oi2'];
+
+function instanceFamily(instanceType: string): string {
+  return (instanceType || '').split('.')[0].toLowerCase();
+}
+
 export interface OpenSearchConstructProps {
   instanceType: string;
   instanceCount: number;
   volumeSize: number;
+  // 'GENERAL' (default) or 'OPTIMIZED' (OR1/OR2/OM2/OI2 instances).
+  engineMode?: 'GENERAL' | 'OPTIMIZED';
 }
 
 export class OpenSearchConstruct extends Construct {
@@ -29,16 +39,24 @@ export class OpenSearchConstruct extends Construct {
       },
     });
 
+    const family = instanceFamily(props.instanceType);
+    const nvmeOnly = NVME_FAMILIES.includes(family);
+    const optimized = props.engineMode === 'OPTIMIZED' || OPTIMIZED_FAMILIES.includes(family);
+
     this.domain = new opensearch.Domain(this, 'Domain', {
       version: opensearch.EngineVersion.openSearch('3.5'),
       capacity: {
         dataNodeInstanceType: props.instanceType,
         dataNodes: props.instanceCount,
       },
-      ebs: {
-        volumeSize: props.volumeSize,
-        volumeType: cdk.aws_ec2.EbsDeviceVolumeType.GP3,
-      },
+      // OI2 uses local NVMe; EBS conflicts with it. The L2 defaults ebs.enabled
+      // to true, so disable it explicitly rather than omitting the prop.
+      ebs: nvmeOnly
+        ? { enabled: false }
+        : {
+            volumeSize: props.volumeSize,
+            volumeType: cdk.aws_ec2.EbsDeviceVolumeType.GP3,
+          },
       nodeToNodeEncryption: true,
       encryptionAtRest: { enabled: true },
       enforceHttps: true,
@@ -56,6 +74,13 @@ export class OpenSearchConstruct extends Construct {
       ],
       removalPolicy: cdk.RemovalPolicy.DESTROY,
     });
+
+    // EngineMode/UseCase have no L2 props yet; set them on the underlying CfnDomain.
+    if (optimized) {
+      const cfnDomain = this.domain.node.defaultChild as opensearch.CfnDomain;
+      cfnDomain.addPropertyOverride('EngineMode', 'OPTIMIZED');
+      cfnDomain.addPropertyOverride('UseCase', 'OBSERVABILITY');
+    }
 
     // IAM role for OSIS pipeline
     this.pipelineRole = new iam.Role(this, 'PipelineRole', {

--- a/aws/cli-installer/README.md
+++ b/aws/cli-installer/README.md
@@ -39,6 +39,25 @@ node bin/cli-installer.mjs --managed \
   --region us-east-1
 ```
 
+By default this creates an optimized-engine domain (`or2.large.search`), recommended
+for log-analytics/observability workloads. Optimized domains require OpenSearch 3.5 or
+later. Pick a different optimized type with `--os-instance-type` (OR2/OM2 take an EBS
+volume via `--os-volume-size`; OI2 uses local NVMe and takes none):
+```bash
+node bin/cli-installer.mjs --managed \
+  --pipeline-name obs-stack-<your-alias> \
+  --region us-east-1 \
+  --engine-mode optimized --os-instance-type om2.xlarge.search
+```
+
+For a standard (non-optimized) domain, pass `--engine-mode general`:
+```bash
+node bin/cli-installer.mjs --managed \
+  --pipeline-name obs-stack-<your-alias> \
+  --region us-east-1 \
+  --engine-mode general --os-instance-type r6g.large.search
+```
+
 **Create a serverless (AOSS) deployment from scratch:**
 ```bash
 node bin/cli-installer.mjs --serverless \

--- a/aws/cli-installer/package-lock.json
+++ b/aws/cli-installer/package-lock.json
@@ -14,7 +14,7 @@
         "@aws-sdk/client-ec2": "^3.1021.0",
         "@aws-sdk/client-eks": "^3.1019.0",
         "@aws-sdk/client-iam": "^3.750.0",
-        "@aws-sdk/client-opensearch": "^3.750.0",
+        "@aws-sdk/client-opensearch": "^3.1078.0",
         "@aws-sdk/client-opensearchserverless": "^3.1018.0",
         "@aws-sdk/client-osis": "^3.750.0",
         "@aws-sdk/client-resource-groups-tagging-api": "^3.1019.0",
@@ -392,49 +392,18 @@
       }
     },
     "node_modules/@aws-sdk/client-opensearch": {
-      "version": "3.1018.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-opensearch/-/client-opensearch-3.1018.0.tgz",
-      "integrity": "sha512-ooDPdUuF3ecKpsyhE4e3XtnUDEwfVDtUoMHEmOTaeV/wnROZuSj9vAYdjnvf4YQuNvNFB7xNL6ksOId5kl3AQw==",
+      "version": "3.1107.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-opensearch/-/client-opensearch-3.1107.0.tgz",
+      "integrity": "sha512-ZJJXj6W3kAxzp5nS0t8KH8iW34POYJ2aXg6yZ9tcwNDy7P+7uPZuoKEbFmmd6LU2Si+MA+IRoq9wK5GANWJG4w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.25",
-        "@aws-sdk/credential-provider-node": "^3.972.26",
-        "@aws-sdk/middleware-host-header": "^3.972.8",
-        "@aws-sdk/middleware-logger": "^3.972.8",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.9",
-        "@aws-sdk/middleware-user-agent": "^3.972.26",
-        "@aws-sdk/region-config-resolver": "^3.972.10",
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/util-endpoints": "^3.996.5",
-        "@aws-sdk/util-user-agent-browser": "^3.972.8",
-        "@aws-sdk/util-user-agent-node": "^3.973.12",
-        "@smithy/config-resolver": "^4.4.13",
-        "@smithy/core": "^3.23.12",
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/hash-node": "^4.2.12",
-        "@smithy/invalid-dependency": "^4.2.12",
-        "@smithy/middleware-content-length": "^4.2.12",
-        "@smithy/middleware-endpoint": "^4.4.27",
-        "@smithy/middleware-retry": "^4.4.44",
-        "@smithy/middleware-serde": "^4.2.15",
-        "@smithy/middleware-stack": "^4.2.12",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/node-http-handler": "^4.5.0",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.7",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.43",
-        "@smithy/util-defaults-mode-node": "^4.2.47",
-        "@smithy/util-endpoints": "^3.3.3",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-retry": "^4.2.12",
-        "@smithy/util-utf8": "^4.2.2",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/credential-provider-node": "^3.972.78",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -743,16 +712,16 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.977.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.1.tgz",
-      "integrity": "sha512-KVtQRtc00ES/y+Sc3vYXeP6pCIcNlBJCZOwvqSy8ZpVGmbM5+IG+AfhuTKQ2oXmIVqZJewaGMMpzPkywC6xg0w==",
+      "version": "3.977.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.6.tgz",
+      "integrity": "sha512-QiaJV4/zDrB4ZY2mfeSXSzSTc36W16sZXcGz+SPFk0CJ26gziO0cS+4LjJUMAbdeeBOvS0k0Aq1cZpfGdUXxSw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.974.2",
         "@aws-sdk/xml-builder": "^3.972.37",
         "@aws/lambda-invoke-store": "^0.3.0",
-        "@smithy/core": "^3.29.8",
-        "@smithy/signature-v4": "^5.6.9",
+        "@smithy/core": "^3.31.1",
+        "@smithy/signature-v4": "^5.6.12",
         "@smithy/types": "^4.16.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
@@ -771,14 +740,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.62",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.62.tgz",
-      "integrity": "sha512-BkDrk2cNjed31IKin/Oksb2ziF+gfuyRskFVuT4EU9Mep7M8Y/d8DJG4+anHme4Vuse7CwaEscwEfGyR6mzBhQ==",
+      "version": "3.972.67",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.67.tgz",
+      "integrity": "sha512-rcIpk5kxUqDaaNa6Xk23pQ6ViY7jlqzmfFWCahQcBT97ddXaXYYwzCen9Tz1Jvo6aJft6wDl5bN44/Jw5B4oLA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.1",
+        "@aws-sdk/core": "^3.977.6",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -787,16 +756,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.64",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.64.tgz",
-      "integrity": "sha512-Wj1FGK2IxY5EccQCvH+niTYhIvDoDujJf2CpRRgS3NpYNEgiFNVItNbJYQjINRlu7fG7jSsXkKV0UWKriEplrw==",
+      "version": "3.972.69",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.69.tgz",
+      "integrity": "sha512-nggwJtZ4eeNsUw5IeWBMXsi1ryct5idi0K+/SCRF3kybLubOMaNTb3XCihXpWMiVpyzyPeIrl0zTkzhBH9porA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.1",
+        "@aws-sdk/core": "^3.977.6",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
-        "@smithy/fetch-http-handler": "^5.6.10",
-        "@smithy/node-http-handler": "^4.9.10",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -805,22 +774,22 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.973.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.7.tgz",
-      "integrity": "sha512-2CefB8cCxDu52P24B8Ay93/cTT199bcSvNHQ8e2f4BjSCF83yErBnTIZEBo0VeIgCfmw+PJKFUXnlQWxm2dkug==",
+      "version": "3.973.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.12.tgz",
+      "integrity": "sha512-pNEf/OeyN5X3VmLKlgSO6TqaWmW10CvI3TfwL1XhsuhYjSLT2VDaxFnCPHnOeQXSaFisMX4jNhpETriqN8DOmg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.1",
-        "@aws-sdk/credential-provider-env": "^3.972.62",
-        "@aws-sdk/credential-provider-http": "^3.972.64",
-        "@aws-sdk/credential-provider-login": "^3.972.69",
-        "@aws-sdk/credential-provider-process": "^3.972.62",
-        "@aws-sdk/credential-provider-sso": "^3.973.6",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.68",
-        "@aws-sdk/nested-clients": "^3.997.36",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/credential-provider-env": "^3.972.67",
+        "@aws-sdk/credential-provider-http": "^3.972.69",
+        "@aws-sdk/credential-provider-login": "^3.972.74",
+        "@aws-sdk/credential-provider-process": "^3.972.67",
+        "@aws-sdk/credential-provider-sso": "^3.973.11",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.73",
+        "@aws-sdk/nested-clients": "^3.997.41",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
-        "@smithy/credential-provider-imds": "^4.4.13",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -829,15 +798,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.69",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.69.tgz",
-      "integrity": "sha512-gM3j0Ie9+FoLNTYODY+QWbg3vCRBc7mR9cRdntxTMkFYIrwfRmuucfavP6HNBlYSuaYww54TNJGej4GFgoPZAg==",
+      "version": "3.972.74",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.74.tgz",
+      "integrity": "sha512-0AQfDcf99TNmqVKv0owHrw/TQs6i4ZE5t9qmz6NvO53bE/sA/tpXhXL9AAcEP1qHc6Zzjd1UMb69+/9zdhvY3g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.1",
-        "@aws-sdk/nested-clients": "^3.997.36",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -846,22 +815,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.30",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.30.tgz",
-      "integrity": "sha512-FMnAnWxc8PG+ZrZ2OBKzY4luCUJhe9CG0B9YwYr4pzrYGLXBS2rl+UoUvjGbAwiptxRL6hyA3lFn03Bv1TLqTw==",
+      "version": "3.972.78",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.78.tgz",
+      "integrity": "sha512-OgPAnfvbGAMWac6yvxJ1ihslrvDpPVwR68D2csospdNCCyPvHk9JLzYKwz48SNiS1T2znDwHauywRKRFfpyYng==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.25",
-        "@aws-sdk/credential-provider-http": "^3.972.27",
-        "@aws-sdk/credential-provider-ini": "^3.972.29",
-        "@aws-sdk/credential-provider-process": "^3.972.25",
-        "@aws-sdk/credential-provider-sso": "^3.972.29",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.29",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/credential-provider-imds": "^4.2.13",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
+        "@aws-sdk/credential-provider-env": "^3.972.67",
+        "@aws-sdk/credential-provider-http": "^3.972.69",
+        "@aws-sdk/credential-provider-ini": "^3.973.12",
+        "@aws-sdk/credential-provider-process": "^3.972.67",
+        "@aws-sdk/credential-provider-sso": "^3.973.11",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.73",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -869,14 +837,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.62",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.62.tgz",
-      "integrity": "sha512-zXYU9UWNL66gtMgNLhmxlrvEokuI7r6G2q7FRGu41Bya4iS30JLelUipJX9SV4zhyCPWJhI9Li54R1d9H8Tq6A==",
+      "version": "3.972.67",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.67.tgz",
+      "integrity": "sha512-IlUEejorGTWKb4/Dm7K5Yw4QxUmXLThLhrvBmzVBqZFTbW72cv9LTcITmo1dsnYriALE4h68mOq4LB99x6sQ7Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.1",
+        "@aws-sdk/core": "^3.977.6",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -885,16 +853,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.973.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.6.tgz",
-      "integrity": "sha512-DobZggy3K49xdCpjeyMou0FQhkoYbluVGNydL6D+lcxF8GoAsttFX0xnH5GmiQ89We5dB6TRpW+CD/VowBH6HQ==",
+      "version": "3.973.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.11.tgz",
+      "integrity": "sha512-gAQBkBZxUB84d71+pPcI9L+jh2ujhuAVxc/4FgGiWFDjkPBlMKxzd5XDtkSXTFX8Ro7ansnT88+XadasxMeCRw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.1",
-        "@aws-sdk/nested-clients": "^3.997.36",
-        "@aws-sdk/token-providers": "3.1096.0",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
+        "@aws-sdk/token-providers": "3.1103.0",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -903,15 +871,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.68",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.68.tgz",
-      "integrity": "sha512-bq+yTt+uWJx60VVp/OIAX5xqUAu/K2Uc3eknWnWl+KtfcU2CQe0uNw6lySrn2t5GKHq7jsV0Z63HiBGVtzr/lg==",
+      "version": "3.972.73",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.73.tgz",
+      "integrity": "sha512-SnlEmQa6SjOgs6iOPLUQl1Eyq4AKiAdPQlkOhFhqNfDtDCwibMGvL6QlkSmf3o6vAUSImzdPCxowT5dfQUZP1A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.1",
-        "@aws-sdk/nested-clients": "^3.997.36",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -1052,17 +1020,17 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.36",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.36.tgz",
-      "integrity": "sha512-b71Suv7L+DnhM0MsQHU4WO42I32kxLZi96PbVhZbxMYIoKnEZz3v+LSrG8fupAoA4cBSshCk1Dl/PeRz49qUSg==",
+      "version": "3.997.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.41.tgz",
+      "integrity": "sha512-RDHqPGQWlF6tatA/Tp3rg6oIwtgN9IVderxE+9av2Y93Dfyu+mO1hZ5Bu2jpfZg2rwdNbsssnwM+sLafIczMlQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.1",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.42",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.43",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
-        "@smithy/fetch-http-handler": "^5.6.10",
-        "@smithy/node-http-handler": "^4.9.10",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -1106,13 +1074,13 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.42",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.42.tgz",
-      "integrity": "sha512-DBV4naZP6HYBlAvPpoQzOP12Wvfou/5rN8yJPXjBTBylU5qwCbh/tXr2MddHoIjgoRkEl/eS+IljiUqvmwey1Q==",
+      "version": "3.996.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.43.tgz",
+      "integrity": "sha512-lKekx8bLBXSv4O+cslk9Zfnw2XKSkWBs3uWL5QGhH2ZAQfNS7FE0vcSSN2vD/AhxX54ZTywWxR4STThoeOXlBA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/signature-v4": "^5.6.9",
+        "@smithy/signature-v4": "^5.6.12",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -1146,15 +1114,15 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1096.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1096.0.tgz",
-      "integrity": "sha512-hdUS2hDppy3vkWeFl5y86RLNU6OWH2mQB09yOSsRefwhhGTSFPkaZvfLDD/9vFcvMzlr8QFQFw3fw2FtrurVQA==",
+      "version": "3.1103.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1103.0.tgz",
+      "integrity": "sha512-N4wy26MNn31ItGVHYHPrEuCIFY4MBBjC+C5v1lJKqIUSA7OZBdhleCY53zCCrXn27hsk7YNOaTuhQu807S4AfQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.1",
-        "@aws-sdk/nested-clients": "^3.997.36",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -1700,9 +1668,9 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.30.0",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.30.0.tgz",
-      "integrity": "sha512-dl2yRglDxfzH9uJ4fSo4zTaAHa0zH7+V7BZMRWy8hEYIKT1BiqMUK/CN6T3ADQ3kbA5N1tmUulroJ2UtONS7Kw==",
+      "version": "3.31.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.31.1.tgz",
+      "integrity": "sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.16.1",
@@ -1713,12 +1681,12 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.4.14",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.14.tgz",
-      "integrity": "sha512-QgbuahIb2qxQeZQvNK0sw3aF3JH5zwH8j2lLp5DUasVXexGGMWULAR+7z0omPXFolCP/m5wN9M5lm9EGdSviTQ==",
+      "version": "4.4.16",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.16.tgz",
+      "integrity": "sha512-QfuLWAkLzptffFW980AFeHZFdqds2B64rpEd3uJ6lgs3xVn9QegGMUgUcj+4d7dRrAsya3r58ZKpku97WcFb4w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.30.0",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -1727,12 +1695,12 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.6.11",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.11.tgz",
-      "integrity": "sha512-o0Zkj1nKqJAoq+a+BrkhU39tRftMNjLwpc/z06Frfl43wpbHrJMaSAVZE4vTqlxtVkNaGaT0bIDxOp7tkFTuQQ==",
+      "version": "5.6.13",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.13.tgz",
+      "integrity": "sha512-4fW86pEUOMbrD5nkbyl/tTvPHHWJFbuB2odl6ps9lWfHoXf9HWh3Q/Smh59qH1g7+c/BSZghX6bbUk4gsiMs8A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.30.0",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -1877,12 +1845,12 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.9.11",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.11.tgz",
-      "integrity": "sha512-slbzbz8taEOzoXv/9y34YNBoE+ZHmddLykCgjDAjvMAsu2nM5s2Gzwa5OGF721tD8s+CKeFUBds5lSj9lcbuDg==",
+      "version": "4.9.13",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.13.tgz",
+      "integrity": "sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.30.0",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -1969,12 +1937,12 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.6.10",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.10.tgz",
-      "integrity": "sha512-EXhWePm3SXJAX38npIy4TXL2Aex/OVgCClTjelN2QHw/U+8CQUH8C7AaxsVzQcYieYPseywn48s89DmvuGjiAg==",
+      "version": "5.6.12",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.12.tgz",
+      "integrity": "sha512-I6KLtq3H0qqSuV9vLglfi8puHqzygzWHOnI4z/Rdoo+q50vvo18vBRdPAvvEtcaKROz7Zn6qnPa14kRfPH6PcQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.30.0",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },

--- a/aws/cli-installer/package.json
+++ b/aws/cli-installer/package.json
@@ -26,7 +26,7 @@
     "@aws-sdk/client-ec2": "^3.1021.0",
     "@aws-sdk/client-eks": "^3.1019.0",
     "@aws-sdk/client-iam": "^3.750.0",
-    "@aws-sdk/client-opensearch": "^3.750.0",
+    "@aws-sdk/client-opensearch": "^3.1078.0",
     "@aws-sdk/client-opensearchserverless": "^3.1018.0",
     "@aws-sdk/client-osis": "^3.750.0",
     "@aws-sdk/client-resource-groups-tagging-api": "^3.1019.0",

--- a/aws/cli-installer/src/aws.mjs
+++ b/aws/cli-installer/src/aws.mjs
@@ -56,6 +56,7 @@ import {
   createSpinner,
   createAsciiAnimation,
 } from './ui.mjs';
+import { buildStorageAndEngineOptions } from './engine.mjs';
 import { SignatureV4 } from '@aws-sdk/signature-v4';
 import { Sha256 } from '@aws-crypto/sha256-js';
 import { HttpRequest } from '@smithy/protocol-http';
@@ -318,11 +319,9 @@ async function createManagedDomain(cfg) {
         DomainName: cfg.osDomainName,
         EngineVersion: cfg.osEngineVersion,
         ClusterConfig: clusterConfig,
-        EBSOptions: {
-          EBSEnabled: true,
-          VolumeType: 'gp3',
-          VolumeSize: cfg.osVolumeSize,
-        },
+        // OI2 uses local NVMe; EBSOptions conflicts with it, so it is omitted for
+        // OI2 and kept (gp3) for OR1/OR2/OM2 and standard types.
+        ...buildStorageAndEngineOptions(cfg),
         // VPCOptions places the domain inside the selected subnets/SGs (private endpoint).
         // Omitting it leaves the domain on a public endpoint (default behavior).
         ...(inVpc ? {

--- a/aws/cli-installer/src/cli.mjs
+++ b/aws/cli-installer/src/cli.mjs
@@ -1,6 +1,17 @@
 import { Command } from 'commander';
 import { createRequire } from 'node:module';
 import { DEFAULTS } from './config.mjs';
+import { EngineMode, isOptimizedInstanceType, isNvmeOnlyInstanceType, OPTIMIZED_MIN_VERSION, DEFAULT_GENERAL_INSTANCE_TYPE } from './engine.mjs';
+
+/**
+ * Normalize an engine-mode flag value (case-insensitive) to an EngineMode
+ * constant. Returns '' for an unrecognized value so validateConfig can flag it.
+ */
+export function normalizeEngineMode(value) {
+  const v = String(value || '').trim().toUpperCase();
+  if (v === EngineMode.OPTIMIZED || v === EngineMode.GENERAL) return v;
+  return '';
+}
 
 const require = createRequire(import.meta.url);
 const { version: PKG_VERSION } = require('../package.json');
@@ -47,6 +58,7 @@ export function parseCli(argv) {
   // OpenSearch — create (managed domain)
   program
     .option('--os-domain-name <name>', 'Domain name for new OpenSearch domain')
+    .option('--engine-mode <mode>', 'Engine mode: general or optimized (OR1/OR2/OM2/OI2 instances)', DEFAULTS.engineMode)
     .option('--os-instance-type <type>', 'Instance type', DEFAULTS.osInstanceType)
     .option('--os-instance-count <n>', 'Number of data nodes', DEFAULTS.osInstanceCount)
     .option('--os-volume-size <gb>', 'EBS volume size in GB', DEFAULTS.osVolumeSize)
@@ -94,7 +106,16 @@ export function parseCli(argv) {
 
   program.parse(argv);
 
-  return optsToConfig(program.opts());
+  const cfg = optsToConfig(program.opts());
+  // Whether --os-volume-size was passed explicitly (vs. the default). Used to
+  // reject an OI2 type combined with an explicit EBS volume size.
+  cfg.osVolumeSizeExplicit = program.getOptionValueSource('osVolumeSize') === 'cli';
+  // The default instance type is optimized (OR2). If the user selects general mode
+  // without naming a type, fall back to a standard type so the two agree.
+  if (cfg.engineMode === EngineMode.GENERAL && program.getOptionValueSource('osInstanceType') !== 'cli') {
+    cfg.osInstanceType = DEFAULT_GENERAL_INSTANCE_TYPE;
+  }
+  return cfg;
 }
 
 function parseDestroyArgs(argv) {
@@ -154,6 +175,7 @@ function optsToConfig(opts) {
     opensearchUser: opts.opensearchUser || 'admin',
     opensearchPassword: opts.opensearchPassword || '',
     osDomainName: opts.osDomainName || '',
+    engineMode: normalizeEngineMode(opts.engineMode),
     osInstanceType: opts.osInstanceType,
     osInstanceCount: Number(opts.osInstanceCount),
     osVolumeSize: Number(opts.osVolumeSize),
@@ -318,6 +340,41 @@ export function validateConfig(cfg) {
     // A VPC domain cannot be reused via a public endpoint reference; VPC only applies to newly created domains.
     if (cfg.osAction === 'reuse') {
       errors.push('VPC options apply only when creating a new OpenSearch domain; omit --vpc-id when reusing an existing endpoint');
+    }
+  }
+
+  // Engine mode / optimized instance family checks (only when creating a domain).
+  if (cfg.osAction === 'create' && cfg.opensearchType !== 'serverless') {
+    if (cfg.engineMode !== EngineMode.GENERAL && cfg.engineMode !== EngineMode.OPTIMIZED) {
+      errors.push(`--engine-mode must be 'general' or 'optimized' (got ${cfg.engineMode || '(empty)'})`);
+    }
+    const typeIsOptimized = isOptimizedInstanceType(cfg.osInstanceType);
+    // The engine mode and the instance family must agree: the optimized engine
+    // runs only on OR1/OR2/OM2/OI2; the general engine runs only on standard types.
+    if (cfg.engineMode === EngineMode.OPTIMIZED && cfg.osInstanceType && !typeIsOptimized) {
+      errors.push(`--engine-mode optimized requires an optimized instance type (OR2/OM2/OI2), got ${cfg.osInstanceType}`);
+    }
+    if (cfg.engineMode === EngineMode.GENERAL && typeIsOptimized) {
+      errors.push(`Instance type ${cfg.osInstanceType} is an optimized type; pass --engine-mode optimized to use it`);
+    }
+    // OI2 uses local NVMe and takes no EBS configuration. Only reject an EBS
+    // volume the user set explicitly; the default is ignored (EBS is omitted for OI2).
+    if (isNvmeOnlyInstanceType(cfg.osInstanceType) && cfg.osVolumeSizeExplicit) {
+      errors.push(`Instance type ${cfg.osInstanceType} uses local NVMe storage and cannot take an EBS volume; omit --os-volume-size`);
+    }
+    // Optimized domains require encryption at rest (always enabled here) and
+    // OpenSearch 3.5 or newer (verified against CreateDomain; the developer guide
+    // still lists 2.11). https://docs.aws.amazon.com/opensearch-service/latest/developerguide/or1.html
+    const optimized = cfg.engineMode === EngineMode.OPTIMIZED || typeIsOptimized;
+    if (optimized) {
+      const { major: minMajor, minor: minMinor } = OPTIMIZED_MIN_VERSION;
+      const m = /^OpenSearch_(\d+)\.(\d+)$/.exec(cfg.osEngineVersion || '');
+      const tooOld = m
+        ? (Number(m[1]) < minMajor || (Number(m[1]) === minMajor && Number(m[2]) < minMinor))
+        : Boolean(cfg.osEngineVersion);
+      if (tooOld) {
+        errors.push(`Optimized domains require OpenSearch ${minMajor}.${minMinor} or newer (got ${cfg.osEngineVersion})`);
+      }
     }
   }
 

--- a/aws/cli-installer/src/config.mjs
+++ b/aws/cli-installer/src/config.mjs
@@ -1,12 +1,18 @@
 /**
  * Default configuration values.
  */
+import { EngineMode, DEFAULT_OPTIMIZED_INSTANCE_TYPE } from './engine.mjs';
+
 export const DEFAULT_REGION = process.env.AWS_DEFAULT_REGION || process.env.AWS_REGION || 'us-east-2';
 
+// Quick-start defaults to the optimized engine (OR2), recommended for
+// log-analytics/observability workloads. r6g is a standard type and is not valid
+// under the optimized engine, so a general deployment must override both fields.
 export const DEFAULTS = {
   pipelineName: `obs-stack-${Math.floor(Date.now() / 1000)}`,
   opensearchType: 'managed',
-  osInstanceType: 'r6g.large.search',
+  engineMode: EngineMode.OPTIMIZED,
+  osInstanceType: DEFAULT_OPTIMIZED_INSTANCE_TYPE,
   osInstanceCount: 1,
   osVolumeSize: 100,
   osEngineVersion: 'OpenSearch_3.5',
@@ -24,6 +30,7 @@ export function createDefaultConfig() {
     pipelineName: DEFAULTS.pipelineName,
     region: '',
     opensearchType: DEFAULTS.opensearchType,
+    engineMode: DEFAULTS.engineMode,
     osAction: '',
     aossCollectionName: '',
     opensearchEndpoint: '',

--- a/aws/cli-installer/src/engine.mjs
+++ b/aws/cli-installer/src/engine.mjs
@@ -1,0 +1,94 @@
+/**
+ * OpenSearch engine mode and optimized-instance-family constants and helpers.
+ *
+ * "Optimized Engine" in AWS managed OpenSearch is the OPTIMIZED EngineMode,
+ * backed by the OR1/OR2/OM2/OI2 instance families. See
+ * https://docs.aws.amazon.com/opensearch-service/latest/developerguide/or1.html
+ */
+
+export const EngineMode = {
+  GENERAL: 'GENERAL',
+  OPTIMIZED: 'OPTIMIZED',
+};
+
+export const UseCase = {
+  SEARCH: 'SEARCH',
+  VECTOR: 'VECTOR',
+  OBSERVABILITY: 'OBSERVABILITY',
+  MIXED: 'MIXED',
+};
+
+// Optimized instance families. OR1/OR2/OM2 use gp3/io1 EBS; OI2 uses local NVMe.
+export const OPTIMIZED_FAMILIES = ['or1', 'or2', 'om2', 'oi2'];
+
+// OI2 uses local NVMe disks and takes no EBS configuration.
+export const NVME_FAMILIES = ['oi2'];
+
+// Optimized Engine domains require OpenSearch 3.5 or later. The developer guide
+// still lists 2.11, but CreateDomain rejects < 3.5 with a ValidationException.
+export const OPTIMIZED_MIN_VERSION = { major: 3, minor: 5 };
+
+/**
+ * The instance family prefix of an OpenSearch instance type, e.g.
+ * 'or1.2xlarge.search' -> 'or1', 'r6g.large.search' -> 'r6g'. Returns '' for
+ * empty input.
+ */
+export function instanceFamily(instanceType) {
+  if (!instanceType) return '';
+  return String(instanceType).split('.')[0].toLowerCase();
+}
+
+/** True when the instance type belongs to an optimized family (OR1/OR2/OM2/OI2). */
+export function isOptimizedInstanceType(instanceType) {
+  return OPTIMIZED_FAMILIES.includes(instanceFamily(instanceType));
+}
+
+/** True when the instance type uses local NVMe and takes no EBS configuration (OI2). */
+export function isNvmeOnlyInstanceType(instanceType) {
+  return NVME_FAMILIES.includes(instanceFamily(instanceType));
+}
+
+// Optimized families offered in the interactive picker, with a short description
+// and the sizes AWS supports. The user selects a family, then a size. OR1 is
+// omitted here in favor of the newer OR2/OM2; free-text --os-instance-type still
+// accepts any valid type.
+export const OPTIMIZED_FAMILY_CHOICES = [
+  { family: 'or2', label: 'OR2 — general-purpose optimized (EBS)', sizes: ['large', 'xlarge', '2xlarge', '4xlarge', '8xlarge', '12xlarge', '16xlarge'] },
+  { family: 'om2', label: 'OM2 — memory-optimized (EBS)', sizes: ['large', 'xlarge', '2xlarge', '4xlarge', '8xlarge', '12xlarge', '16xlarge'] },
+  { family: 'oi2', label: 'OI2 — local NVMe, no EBS', sizes: ['large', 'xlarge', '2xlarge', '4xlarge', '8xlarge', '12xlarge', '16xlarge', '24xlarge', '32xlarge'] },
+];
+
+// Opinionated default for optimized deployments: general-purpose OR2, small size.
+export const DEFAULT_OPTIMIZED_INSTANCE_TYPE = 'or2.large.search';
+
+// Default instance type for the general (standard-engine) opt-out path.
+export const DEFAULT_GENERAL_INSTANCE_TYPE = 'r6g.large.search';
+
+/** Compose an OpenSearch instance type from a family and size, e.g. ('or2','large') -> 'or2.large.search'. */
+export function optimizedInstanceType(family, size) {
+  return `${family}.${size}.search`;
+}
+
+/**
+ * Build the storage and engine-mode fields for CreateDomain from a config.
+ * OI2 uses local NVMe and takes no EBSOptions; OR1/OR2/OM2 and standard types
+ * keep gp3 EBS. Optimized instances (by flag or type) get EngineMode=OPTIMIZED
+ * and UseCase=OBSERVABILITY. Returns an object spread directly into CreateDomain.
+ */
+export function buildStorageAndEngineOptions(cfg) {
+  const options = {};
+  if (!isNvmeOnlyInstanceType(cfg.osInstanceType)) {
+    options.EBSOptions = {
+      EBSEnabled: true,
+      VolumeType: 'gp3',
+      VolumeSize: cfg.osVolumeSize,
+    };
+  }
+  const optimized = cfg.engineMode === EngineMode.OPTIMIZED || isOptimizedInstanceType(cfg.osInstanceType);
+  if (optimized) {
+    options.EngineMode = EngineMode.OPTIMIZED;
+    options.UseCase = UseCase.OBSERVABILITY;
+  }
+  return options;
+}
+

--- a/aws/cli-installer/src/interactive.mjs
+++ b/aws/cli-installer/src/interactive.mjs
@@ -4,6 +4,7 @@ import {
   saveCursor, clearFromCursor,
 } from './ui.mjs';
 import { createDefaultConfig, DEFAULTS, DEFAULT_REGION } from './config.mjs';
+import { EngineMode, OPTIMIZED_FAMILY_CHOICES, DEFAULT_GENERAL_INSTANCE_TYPE, optimizedInstanceType, isNvmeOnlyInstanceType } from './engine.mjs';
 import { listDomains, listCollections, listWorkspaces, listApplications, listVpcs, listSubnets, listSecurityGroups } from './aws.mjs';
 
 const CUSTOM_INPUT = Symbol('custom');
@@ -242,7 +243,37 @@ async function stepOpenSearch(cfg) {
       if (domainName === GoBack) { clearFromCursor(); continue; }
       cfg.osDomainName = domainName;
 
-      const instType = await eInput({ message: 'Instance type', default: cfg.osInstanceType || DEFAULTS.osInstanceType });
+      const engineMode = await eSelect({
+        message: 'Engine mode',
+        choices: [
+          { name: `Optimized ${theme.muted('— OR2/OM2/OI2, recommended for log analytics/observability')}`, value: EngineMode.OPTIMIZED },
+          { name: `General  ${theme.muted('— standard instances (e.g. r6g), EBS storage')}`, value: EngineMode.GENERAL },
+        ],
+        default: cfg.engineMode || DEFAULTS.engineMode,
+      });
+      if (engineMode === GoBack) { clearFromCursor(); continue; }
+      cfg.engineMode = engineMode;
+
+      let instType;
+      if (engineMode === EngineMode.OPTIMIZED) {
+        // Select a family, then a size, and compose the instance type.
+        const family = await eSelect({
+          message: 'Optimized instance family',
+          choices: OPTIMIZED_FAMILY_CHOICES.map((f) => ({ name: f.label, value: f.family })),
+          default: OPTIMIZED_FAMILY_CHOICES[0].family,
+        });
+        if (family === GoBack) { clearFromCursor(); continue; }
+        const sizes = OPTIMIZED_FAMILY_CHOICES.find((f) => f.family === family).sizes;
+        const size = await eSelect({
+          message: 'Instance size',
+          choices: sizes.map((s) => ({ name: s, value: s })),
+          default: sizes[0],
+        });
+        if (size === GoBack) { clearFromCursor(); continue; }
+        instType = optimizedInstanceType(family, size);
+      } else {
+        instType = await eInput({ message: 'Instance type', default: DEFAULT_GENERAL_INSTANCE_TYPE });
+      }
       if (instType === GoBack) { clearFromCursor(); continue; }
       cfg.osInstanceType = instType;
 
@@ -254,13 +285,18 @@ async function stepOpenSearch(cfg) {
       if (instCount === GoBack) { clearFromCursor(); continue; }
       cfg.osInstanceCount = Number(instCount);
 
-      const volSize = await eInput({
-        message: 'EBS volume size (GB)',
-        default: String(cfg.osVolumeSize || DEFAULTS.osVolumeSize),
-        validate: (v) => /^\d+$/.test(v.trim()) && Number(v) >= 10 || 'Must be at least 10 GB',
-      });
-      if (volSize === GoBack) { clearFromCursor(); continue; }
-      cfg.osVolumeSize = Number(volSize);
+      // OI2 uses local NVMe and takes no EBS volume, so skip the size prompt.
+      if (isNvmeOnlyInstanceType(cfg.osInstanceType)) {
+        cfg.osVolumeSize = 0;
+      } else {
+        const volSize = await eInput({
+          message: 'EBS volume size (GB)',
+          default: String(cfg.osVolumeSize || DEFAULTS.osVolumeSize),
+          validate: (v) => /^\d+$/.test(v.trim()) && Number(v) >= 10 || 'Must be at least 10 GB',
+        });
+        if (volSize === GoBack) { clearFromCursor(); continue; }
+        cfg.osVolumeSize = Number(volSize);
+      }
 
       const engineVer = await eInput({ message: 'Engine version', default: cfg.osEngineVersion || DEFAULTS.osEngineVersion });
       if (engineVer === GoBack) { clearFromCursor(); continue; }

--- a/aws/cli-installer/src/main.mjs
+++ b/aws/cli-installer/src/main.mjs
@@ -1,5 +1,6 @@
 import { writeFileSync } from 'node:fs';
 import { parseCli, applyQuickDefaults, validateConfig, fillDryRunPlaceholders } from './cli.mjs';
+import { EngineMode, isOptimizedInstanceType, isNvmeOnlyInstanceType } from './engine.mjs';
 import { renderPipeline } from './render.mjs';
 import {
   checkRequirements,
@@ -268,7 +269,13 @@ function printSummary(cfg) {
     osEntries.push(['Domain name', cfg.osDomainName]);
     osEntries.push(['Instance type', cfg.osInstanceType]);
     osEntries.push(['Instance count', String(cfg.osInstanceCount)]);
-    osEntries.push(['Volume size', `${cfg.osVolumeSize} GB`]);
+    if (isNvmeOnlyInstanceType(cfg.osInstanceType)) {
+      osEntries.push(['Volume size', 'local NVMe (no EBS)']);
+    } else {
+      osEntries.push(['Volume size', `${cfg.osVolumeSize} GB`]);
+    }
+    const optimized = cfg.engineMode === EngineMode.OPTIMIZED || isOptimizedInstanceType(cfg.osInstanceType);
+    osEntries.push(['Engine mode', optimized ? 'optimized' : 'general']);
     osEntries.push(['Engine version', cfg.osEngineVersion]);
     if (cfg.vpcId) {
       osEntries.push(['Network', `VPC ${cfg.vpcId}`]);

--- a/aws/cli-installer/test/unit.test.mjs
+++ b/aws/cli-installer/test/unit.test.mjs
@@ -352,6 +352,10 @@ function baseCfg(overrides = {}) {
     region: 'us-east-1',
     osAction: 'create',
     osDomainName: 'obs-stack-test',
+    engineMode: 'GENERAL',
+    osInstanceType: 'r6g.large.search',
+    osVolumeSize: 100,
+    osEngineVersion: 'OpenSearch_3.5',
     iamAction: 'create',
     apsAction: 'create',
     dashboardsAction: 'create',
@@ -445,6 +449,140 @@ describe('validateConfig — OSI pipeline role', () => {
   it('still requires --iam-role-arn when reusing a role', () => {
     const errors = validateConfig(baseCfg({ iamAction: 'reuse', iamRoleArn: '' }));
     assert.ok(errors.some((e) => e.includes('--iam-role-arn required when reusing')));
+  });
+});
+
+import {
+  EngineMode,
+  instanceFamily,
+  isOptimizedInstanceType,
+  isNvmeOnlyInstanceType,
+  buildStorageAndEngineOptions,
+} from '../src/engine.mjs';
+import { normalizeEngineMode } from '../src/cli.mjs';
+
+describe('buildStorageAndEngineOptions — CreateDomain storage/engine fields', () => {
+  it('standard type keeps gp3 EBS and no engine mode', () => {
+    const o = buildStorageAndEngineOptions({ osInstanceType: 'r6g.large.search', osVolumeSize: 100, engineMode: 'GENERAL' });
+    assert.deepEqual(o.EBSOptions, { EBSEnabled: true, VolumeType: 'gp3', VolumeSize: 100 });
+    assert.equal(o.EngineMode, undefined);
+    assert.equal(o.UseCase, undefined);
+  });
+
+  it('OR1 keeps EBS and sets OPTIMIZED + OBSERVABILITY', () => {
+    const o = buildStorageAndEngineOptions({ osInstanceType: 'or1.2xlarge.search', osVolumeSize: 200, engineMode: 'OPTIMIZED' });
+    assert.deepEqual(o.EBSOptions, { EBSEnabled: true, VolumeType: 'gp3', VolumeSize: 200 });
+    assert.equal(o.EngineMode, 'OPTIMIZED');
+    assert.equal(o.UseCase, 'OBSERVABILITY');
+  });
+
+  it('OI2 omits EBSOptions (local NVMe) — fails without the conditional fix', () => {
+    const o = buildStorageAndEngineOptions({ osInstanceType: 'oi2.large.search', osVolumeSize: 100, engineMode: 'OPTIMIZED' });
+    assert.equal('EBSOptions' in o, false);
+    assert.equal(o.EngineMode, 'OPTIMIZED');
+    assert.equal(o.UseCase, 'OBSERVABILITY');
+  });
+});
+
+describe('engine — instance family helpers', () => {
+  it('derives the family prefix from an instance type', () => {
+    assert.equal(instanceFamily('or1.2xlarge.search'), 'or1');
+    assert.equal(instanceFamily('r6g.large.search'), 'r6g');
+    assert.equal(instanceFamily('OI2.large.search'), 'oi2');
+    assert.equal(instanceFamily(''), '');
+  });
+
+  it('recognizes optimized families (OR1/OR2/OM2/OI2)', () => {
+    for (const t of ['or1.large.search', 'or2.large.search', 'om2.large.search', 'oi2.large.search']) {
+      assert.equal(isOptimizedInstanceType(t), true, t);
+    }
+    assert.equal(isOptimizedInstanceType('r6g.large.search'), false);
+    assert.equal(isOptimizedInstanceType('m6g.large.search'), false);
+  });
+
+  it('recognizes OI2 as NVMe-only, others as EBS-backed', () => {
+    assert.equal(isNvmeOnlyInstanceType('oi2.large.search'), true);
+    assert.equal(isNvmeOnlyInstanceType('or1.large.search'), false);
+    assert.equal(isNvmeOnlyInstanceType('r6g.large.search'), false);
+  });
+
+  it('normalizes engine-mode flag values (case-insensitive)', () => {
+    assert.equal(normalizeEngineMode('optimized'), EngineMode.OPTIMIZED);
+    assert.equal(normalizeEngineMode('GENERAL'), EngineMode.GENERAL);
+    assert.equal(normalizeEngineMode('bogus'), '');
+    assert.equal(normalizeEngineMode(''), '');
+  });
+});
+
+describe('validateConfig — engine mode / optimized instances', () => {
+  it('standard general domain is unchanged (no errors)', () => {
+    assert.deepEqual(validateConfig(baseCfg()), []);
+  });
+
+  it('accepts an optimized OR2 domain with EBS', () => {
+    const errors = validateConfig(baseCfg({
+      engineMode: 'OPTIMIZED',
+      osInstanceType: 'or2.large.search',
+    }));
+    assert.deepEqual(errors, []);
+  });
+
+  it('accepts an optimized OI2 domain (no EBS)', () => {
+    const errors = validateConfig(baseCfg({
+      engineMode: 'OPTIMIZED',
+      osInstanceType: 'oi2.large.search',
+      osVolumeSizeExplicit: false,
+    }));
+    assert.deepEqual(errors, []);
+  });
+
+  it('rejects optimized mode with a standard instance type', () => {
+    const errors = validateConfig(baseCfg({
+      engineMode: 'OPTIMIZED',
+      osInstanceType: 'r6g.large.search',
+    }));
+    assert.ok(errors.some((e) => e.includes('optimized requires an optimized instance type')));
+  });
+
+  it('rejects general mode with an optimized instance type', () => {
+    const errors = validateConfig(baseCfg({
+      engineMode: 'GENERAL',
+      osInstanceType: 'or2.large.search',
+    }));
+    assert.ok(errors.some((e) => e.includes('pass --engine-mode optimized to use it')));
+  });
+
+  it('OI2 with an explicit EBS volume size is rejected', () => {
+    const errors = validateConfig(baseCfg({
+      engineMode: 'OPTIMIZED',
+      osInstanceType: 'oi2.large.search',
+      osVolumeSize: 100,
+      osVolumeSizeExplicit: true,
+    }));
+    assert.ok(errors.some((e) => e.includes('local NVMe') && e.includes('omit --os-volume-size')));
+  });
+
+  it('rejects an invalid engine mode', () => {
+    const errors = validateConfig(baseCfg({ engineMode: 'turbo', osInstanceType: 'or2.large.search' }));
+    assert.ok(errors.some((e) => e.includes("--engine-mode must be 'general' or 'optimized'")));
+  });
+
+  it('rejects optimized domains on an engine older than 3.5', () => {
+    const errors = validateConfig(baseCfg({
+      engineMode: 'OPTIMIZED',
+      osInstanceType: 'or2.large.search',
+      osEngineVersion: 'OpenSearch_2.11',
+    }));
+    assert.ok(errors.some((e) => e.includes('3.5 or newer')));
+  });
+
+  it('accepts optimized domains on OpenSearch 3.5', () => {
+    const errors = validateConfig(baseCfg({
+      engineMode: 'OPTIMIZED',
+      osInstanceType: 'or2.large.search',
+      osEngineVersion: 'OpenSearch_3.5',
+    }));
+    assert.deepEqual(errors, []);
   });
 });
 


### PR DESCRIPTION
## What

Adds optimized-engine support for AWS managed OpenSearch domains in the CLI installer (`aws/cli-installer`) and CDK (`aws/cdk`). "Optimized Engine" is the `OPTIMIZED` `EngineMode` on `CreateDomain`, backed by the OR1/OR2/OM2/OI2 instance families.

Files touched: `aws/cli-installer/src/{engine.mjs (new),aws.mjs,cli.mjs,config.mjs,interactive.mjs,main.mjs}`, `aws/cli-installer/test/unit.test.mjs`, `aws/cli-installer/{package.json,package-lock.json,README.md}`, `aws/cdk/{bin/app.ts,lib/infra-stack.ts,lib/opensearch.ts}`.

Fixes #332.

## Root cause

**EBSOptions is sent unconditionally.** Both the CLI (`aws.mjs` `CreateDomainCommand`) and the CDK (`opensearch.ts`, via the L2 `Domain` construct whose `ebs.enabled` defaults to `true`) always attach an EBS volume. OI2 uses local NVMe and takes no EBS configuration, so an OI2 instance type conflicts with the EBS volume. There was also no way to request the optimized engine: `EngineMode`/`UseCase` were never set.

## Fix

- **New `engine.mjs`** with typed constants: `EngineMode` (`GENERAL`/`OPTIMIZED`), `UseCase`, optimized families (OR1/OR2/OM2/OI2), NVMe family (OI2), and family/NVMe detection helpers. No raw instance-family strings scattered across the code.
- **Conditional EBSOptions.** `buildStorageAndEngineOptions` omits `EBSOptions` for OI2 and keeps `gp3` for OR1/OR2/OM2 and standard types. The CDK path sets `ebs: { enabled: false }` for OI2 (omitting the prop is not enough — the L2 default is `true`) and applies `EngineMode`/`UseCase` through a `CfnDomain` property override, since the L2 has no props for them yet.
- **Opinionated defaults.** Quick-start creates an optimized `or2.large.search` domain. `--engine-mode general` is the standard opt-out and defaults to `r6g.large.search`. The interactive wizard offers Optimized (default) with an OR2/OM2/OI2 family selector, then a size.
- **Validation.** `validateConfig` requires the engine mode and instance family to agree (optimized engine needs an optimized type; general engine rejects an optimized type), rejects an OI2 type combined with an explicit `--os-volume-size`, and requires OpenSearch 3.5+ for optimized domains.
- **SDK bump.** `@aws-sdk/client-opensearch` to `^3.1078.0`, the first release that models `EngineMode`/`UseCase`. Older versions silently drop these input fields, so on the previous pin the request looked correct but omitted them.

Optimized domains require encryption at rest and Graviton master nodes when dedicated masters are enabled. Encryption at rest is already enabled here, and this stack does not configure dedicated masters, so neither adds a new constraint.

Terraform is out of scope. `terraform/aws/` runs self-hosted OpenSearch on EKS pods, not AWS managed OpenSearch, so instance-family selection does not apply there.

## Validation

- **CLI unit tests: 109 pass, 0 fail** (`node --test test/unit.test.mjs`). New sub-cases cover family detection, `buildStorageAndEngineOptions` (OI2 omits EBSOptions — fails without the fix; OR2/standard keep it), engine-mode/family agreement, the OI2 explicit-EBS rejection, and the 3.5 version gate.
- **CDK: `tsc` builds clean.** An isolated `InfraStack` synth confirms the templates: default → `EngineMode=OPTIMIZED`, `UseCase=OBSERVABILITY`, `or2.large.search`, gp3 EBS; OI2 → `EBSOptions.EBSEnabled=false`; general → no `EngineMode`, `r6g.large.search`, gp3 EBS.
- **Live create.** A single-node `oi2.large.search` optimized domain (no EBS, no dedicated masters) was created via `CreateDomain` and reached Active with `EngineMode=OPTIMIZED`, `UseCase=OBSERVABILITY`, `EBSEnabled=false`, then deleted. A full quick-mode installer run also created a working `or2.large.search` optimized stack (domain, OSIS pipeline, AMP, UI). No full CDK deploy against live AWS was run.
- **Doc discrepancy found.** `CreateDomain` rejected `OpenSearch_2.11` with `ValidationException: Optimized Engine domains require OpenSearch 3.5 or later`. The developer guide (https://docs.aws.amazon.com/opensearch-service/latest/developerguide/or1.html) still lists 2.11 as the minimum for new domains; the validation here uses the enforced 3.5.

References:
- Issue: https://github.com/opensearch-project/observability-stack/issues/332
- OR1 optimized instances: https://docs.aws.amazon.com/opensearch-service/latest/developerguide/or1.html
- CreateDomain API: https://docs.aws.amazon.com/opensearch-service/latest/APIReference/API_CreateDomain.html
