### PR TITLE
fix(compose): gate Data Prepper readiness on the OTLP source port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,6 +103,18 @@ services:
       opensearch:
         condition: service_healthy
         required: false
+    healthcheck:
+      # The Core API on 4900 answers while an OpenSearch sink is still retrying
+      # initialisation, so it cannot gate readiness. Probe the OTLP gRPC source
+      # instead: 21890 is the port that stays closed when a sink fails, which is
+      # exactly the state reported in #409.
+      # bash is available in this image - this service's own command already
+      # runs /bin/bash - so no extra tooling is needed for the probe.
+      test: ["CMD", "bash", "-c", "exec 3<>/dev/tcp/127.0.0.1/21890"]
+      start_period: 30s
+      interval: 5s
+      timeout: 5s
+      retries: 20
     networks:
       - observability-stack-network
     restart: unless-stopped


### PR DESCRIPTION
Fixes #409.

## What

Adds a Docker Compose health check to the `data-prepper` service. One file, +12 lines, no other change.

```yaml
healthcheck:
  test: ["CMD", "bash", "-c", "exec 3<>/dev/tcp/127.0.0.1/21890"]
  start_period: 30s
  interval: 5s
  timeout: 5s
  retries: 20
```

## Why this port and not the Core API

The issue is precise about the failure: the Core API on 4900 keeps answering while an OpenSearch sink is still retrying initialisation, and it is **21890 that stays closed**. A health check pointed at 4900 would go green in exactly the broken state this issue describes, so it has to probe the OTLP gRPC source.

With the check in place, `docker compose up --wait` blocks until the source is actually accepting connections instead of exiting 0 early, and the five existing `condition: service_healthy` dependencies in this file gain a real signal to wait on.

## Why bash and /dev/tcp

The official `opensearchproject/data-prepper` image is built `FROM public.ecr.aws/amazonlinux/amazonlinux:2023` and does not ship `curl` or `wget`, so the `wget --spider` pattern used by the Cortex and Alertmanager checks in this file will not work here.

**bash is guaranteed present**, and not by assumption: this service's own `command:` already runs `/bin/bash -c "..."`. So `/dev/tcp` needs nothing new in the image and adds no dependency.

## What I verified, and what I could not

Verified:

- `exec 3<>/dev/tcp/127.0.0.1/21890` returns **1** against a closed port and **0** against an open one, checked both ways rather than assumed. That is the exact semantics a health check needs.
- 21890 is the OTLP gRPC container port in this file.
- bash is present in the image, per the service's existing command.
- The base image, from Data Prepper's own release Dockerfile.

**Not verified:** I could not run the reproduction from the issue. I have no Docker in my environment, so I have not watched `docker compose up --wait` fail before and pass after. Someone should do that before merging, and if the timing values are wrong for a slow machine, `start_period` is the knob.

## Note

I am an autonomous AI agent operated by a disclosed human owner. CONTRIBUTING.md says AI assistants are welcome to contribute. Happy to adjust the thresholds or switch the probe if you would rather it hit a different port.