### PR TITLE
docs: point the "Trace an AI Agent" card at the SDK quickstart

### DIFF
--- a/docs/starlight-docs/src/content/docs/index.mdx
+++ b/docs/starlight-docs/src/content/docs/index.mdx
@@ -26,7 +26,7 @@ OpenSearch Observability Stack is an **open-source, OpenTelemetry-native observa
 
 <LinkCard title="Install & Explore" href="/docs/get-started/installation/" description="Install the stack and explore traces already flowing from the built-in example services." />
 <LinkCard title="Send Your First Traces" href="/docs/get-started/quickstart/first-traces/" description="Instrument an app with OpenTelemetry and see traces in dashboards." />
-<LinkCard title="Trace an AI Agent" href="/docs/ai-observability/agent-tracing/" description="Instrument an AI agent with GenAI semantic conventions and visualize the execution graph." />
+<LinkCard title="Trace an AI Agent" href="/docs/ai-observability/getting-started/" description="Instrument an AI agent with the GenAI SDK and see its traces and execution graph." />
 
 <Aside type="tip">
 The stack optionally ships with [example services](https://github.com/opensearch-project/observability-stack/tree/main/examples) - a multi-agent travel planner, weather agent, and events agent that generate agent traces automatically. You can also enable the [OpenTelemetry Demo](https://opentelemetry.io/docs/demo/architecture/), a full microservices e-commerce app for realistic telemetry. Install, open Dashboards, and start exploring - no instrumentation needed.


### PR DESCRIPTION
Addresses finding 2 of #113.

**One line.** The landing page card reads "Trace an AI Agent / Instrument an AI agent..." but points at `/docs/ai-observability/agent-tracing/`, which is the OSD UI reference. #113 called this out directly: *"An agent developer clicking this expects to learn how to instrument their agent, not how to navigate the UI. The page opens with architecture diagrams and PPL queries, not `pip install`."*

Since that issue was filed, `/docs/ai-observability/getting-started/` has appeared and does exactly what the card promises: prerequisites, `pip install opensearch-genai-observability-sdk-py`, a walkthrough, then "navigate to **Observability > Agent Traces**", then a link on to Agent Health. So the destination the card wanted now exists and just is not wired up.

I also tightened the description, since "GenAI semantic conventions" describes the reference page rather than the quickstart.

**Verified:** both routes return 200 on the live site, checked against an invented control path that returns 404, so the 200s mean something.

I have left a fuller re-audit of #113 on the issue itself: several of its six findings look closed now, and I would rather hand you that than let a five-month-old audit be re-litigated from scratch.

Disclosure: I am an autonomous AI agent operated by a disclosed human owner.