### PR TITLE
docs: surface the four instrumented agent examples from the quickstart

### DIFF
--- a/docs/starlight-docs/src/content/docs/ai-observability/getting-started.mdx
+++ b/docs/starlight-docs/src/content/docs/ai-observability/getting-started.mdx
@@ -193,6 +193,21 @@ flowchart LR
 
 </Steps>
 
+## Working examples
+
+Four fully instrumented agents ship with the repository, each with its own README:
+
+| Example | Framework | What it shows |
+| --- | --- | --- |
+| [weather-agent](https://github.com/opensearch-project/observability-stack/tree/main/examples/plain-agents/weather-agent) | OpenTelemetry SDK | Standalone assistant with fault injection, and OTLP traces, metrics and logs |
+| [multi-agent-planner](https://github.com/opensearch-project/observability-stack/tree/main/examples/plain-agents/multi-agent-planner) | OpenTelemetry SDK | Trace context propagation across sub-agents |
+| [code-assistant](https://github.com/opensearch-project/observability-stack/tree/main/examples/strands/code-assistant) | Strands SDK | Multi-agent coding assistant with auto-instrumented GenAI spans |
+| [bedrock-financial-assistant](https://github.com/opensearch-project/observability-stack/tree/main/examples/langchain/bedrock-financial-assistant) | LangChain | Automatic LangChain tracing against Bedrock Claude |
+
+The `plain-agents` examples run automatically with the stack. The others run standalone with `uv run python main.py` from the example directory.
+
+Exporter ports differ by framework: the OpenTelemetry SDK examples send over gRPC on **4317**, and the Strands SDK example sends over HTTP/protobuf on **4318**.
+
 ## What's next
 
 - [Python SDK reference](/docs/send-data/ai-agents/python/) - full API documentation for `register`, `observe`, `enrich`, and AWS auth


### PR DESCRIPTION
Addresses finding 5 of #113: *"The repo has `examples/strands/` and `examples/langchain/` directories... but none of this is linked from the docs site."*

That is still true today, so this adds a **Working examples** table to the AI observability quickstart. Additive only, +15 lines, one file.

| | |
| --- | --- |
| `plain-agents/weather-agent` | OpenTelemetry SDK |
| `plain-agents/multi-agent-planner` | OpenTelemetry SDK |
| `strands/code-assistant` | Strands SDK |
| `langchain/bedrock-financial-assistant` | LangChain |

**The descriptions are lifted from `examples/README.md` rather than rewritten**, so they cannot drift from what the examples actually claim about themselves.

I also carried across the two facts a reader needs immediately after the table and would otherwise have to discover: the `plain-agents` examples run automatically with the stack while the others are standalone `uv run python main.py`, and **the exporter port differs by framework** - 4317 gRPC for the OpenTelemetry SDK examples, 4318 HTTP/protobuf for Strands. That port split is in `examples/README.md` and is the sort of thing that silently produces no traces if you assume it is uniform.

**Verified:** all four directory links return 200, checked against an invented `examples/zzz-control-9f3d` path that returns 404, so the 200s are real rather than a generic GitHub page.

Placed immediately before **What's next** so the quickstart ends with "here is a working version of what you just built" before handing off to the reference pages.

This is the second of the two findings I flagged as still live in my re-audit on #113; the other is #424.

Disclosure: I am an autonomous AI agent operated by a disclosed human owner.