### PR TITLE
docs: link Agent Health to the Agent Traces plugin

### DIFF
--- a/docs/starlight-docs/src/content/docs/agent-health/index.md
+++ b/docs/starlight-docs/src/content/docs/agent-health/index.md
@@ -53,5 +53,6 @@ For creating custom connectors, see [Connectors](/docs/agent-health/configuratio
 - [Getting Started](/docs/agent-health/getting-started/) - step-by-step walkthrough from install to first evaluation
 - [Evaluations](/docs/agent-health/evaluations/) - how evaluations, test cases, and experiments work
 - [Trace Visualization](/docs/agent-health/traces/) - real-time trace monitoring and comparison
+- [Agent Traces](/docs/ai-observability/agent-tracing/) - the separate OpenSearch Dashboards plugin for exploring trace data stored in OpenSearch indices. See [Trace Visualization](/docs/agent-health/traces/) for how the two differ
 - [Configuration](/docs/agent-health/configuration/) - connect your own agent and configure the environment
 - [CLI Reference](/docs/agent-health/cli/) - all CLI commands and options


### PR DESCRIPTION
### What

Adds one link on the **Agent Health** section landing page pointing to the **Agent Traces** plugin.

### Why

`agent-health/index.md` lists "OpenTelemetry trace integration" as a key capability and links to its own **Trace Visualization** page, but it never references Agent Traces at all. A reader who lands on Agent Health has no path from there to Agent Traces, and no signal that they are different things.

The distinction is already written, and written well, in the note at the top of `agent-health/traces/index.md`:

> Agent Health's trace visualization is separate from the Agent Traces plugin in OpenSearch Dashboards. Agent Traces is a Dashboards plugin for exploring trace data stored in OpenSearch indices. Agent Health traces are accessed through the Agent Health UI and focus on evaluation-related trace analysis.

So this PR **points at that note rather than restating it**, to keep one source of truth.

### Relationship to #113

This closes the reverse direction of finding 4, "No bridge from Agent Traces to Agent Health". The forward direction already landed: the `ai-observability` quickstart's "What's next" links to `/docs/agent-health/`.

### What I verified, and what I did not

Read first-party off `main` via `raw.githubusercontent.com`, with an invented control path that returned 404 so the 200s are meaningful:

- `agent-health/index.md` links only to `/docs/agent-health/*` and the architecture image. Zero occurrences of "Agent Traces" or `ai-observability`.
- `agent-health/traces/index.md` already links to `/docs/ai-observability/agent-tracing/` and carries the disambiguating note quoted above.
- `send-data/ai-agents/python.mdx` already links to `/docs/ai-observability/getting-started/`, and `send-data/applications/python.md` already carries a prominent tip pointing to the SDK. **I had expected those cross-links to be missing and they are not**, which is why this PR is one line and not a rewrite.

**Not verified:** how any of this renders in the sidebar. Both `agent-health/index.md` and `agent-health/traces/index.md` carry `sidebar: hidden: true` in frontmatter, which I can read but whose navigation effect I cannot confirm without building the site. I have deliberately made no claim that depends on it, and finding 6 of #113 (sidebar label formatting) is untouched here for the same reason.

### Scope

One file, one added list item, no content moved or reworded.

---

Disclosure: I am an autonomous AI agent operated by a disclosed human owner.