### PR TITLE
docs: point the first-traces quickstart at auto-instrumentation and APM

### DIFF
--- a/docs/starlight-docs/src/content/docs/get-started/quickstart/first-traces.md
+++ b/docs/starlight-docs/src/content/docs/get-started/quickstart/first-traces.md
@@ -9,6 +9,13 @@ description: Instrument your application to send traces to the Observability Sta
 pip install opentelemetry-api opentelemetry-sdk opentelemetry-exporter-otlp
 ```
 
+:::tip[Most applications do not need this code]
+The example below instruments a span by hand so you can see what a trace is made
+of. For a real service, [auto-instrumentation](/docs/send-data/opentelemetry/auto-instrumentation/)
+is usually the faster path: it emits HTTP, database and framework spans with no
+code changes, and is available for Python, Java, Node.js, Go, .NET and Ruby.
+:::
+
 ## 2. Send traces
 
 ```python
@@ -46,4 +53,5 @@ For other languages, see [Send Data](/docs/send-data/).
 
 - [Create Your First Dashboard](/docs/get-started/quickstart/first-dashboard/) - build custom visualizations
 - [Agent Tracing](/docs/ai-observability/agent-tracing/) - trace AI agent workflows with GenAI semantic conventions
+- [Application Monitoring](/docs/apm/) - service maps and RED metrics built from the traces you just sent
 - [Send Data](/docs/send-data/) - more instrumentation options

--- a/docs/starlight-docs/src/content/docs/get-started/quickstart/first-traces.md
+++ b/docs/starlight-docs/src/content/docs/get-started/quickstart/first-traces.md
@@ -9,7 +9,7 @@ description: Instrument your application to send traces to the Observability Sta
 pip install opentelemetry-api opentelemetry-sdk opentelemetry-exporter-otlp
 ```
 
-:::tip[Most applications do not need this code]
+:::tip[OpenTelemetry auto-instrumentation]
 The example below instruments a span by hand so you can see what a trace is made
 of. For a real service, [auto-instrumentation](/docs/send-data/opentelemetry/auto-instrumentation/)
 is usually the faster path: it emits HTTP, database and framework spans with no


### PR DESCRIPTION
Addresses findings **6** and part of **1** from #112, in the one file where both are visible. Two additions, one file, nothing moved or reworded.

### 1. The quickstart never mentions auto-instrumentation

`first-traces.md` teaches manual span creation and links only to `/docs/send-data/` for "other languages". #112 calls auto-instrumentation "the 80% path for APM users", and it is already documented for **six** languages, but the getting-started flow never points at it. A reader following this page writes code they probably do not need to write.

This adds a tip above the example, and **deliberately keeps the manual example**, because seeing a span built by hand is the point of the page.

### 2. Next steps skip Application Monitoring entirely

Current Next steps are Create Your First Dashboard, Agent Tracing, and Send Data. Someone who has just produced their first traces is never told that service maps and RED metrics are built from exactly those traces. That is the single link an APM reader most needs at that moment, and its absence is the concrete form of #112's "next steps jump to dashboards and agent tracing, skipping service maps entirely".

### Audited against `main` first, and #112 is in a different state to #113

I re-checked #112's findings before writing this, the same way I did for #113. Unlike that issue, whose headline finding had already been fixed, **most of #112 is still live**:

| # | finding | status on `main` today |
|---|---|---|
| 1 | first-traces too thin | live: Python only, manual only, no screenshots, Next steps skip APM |
| 4 | landing quickstarts agent-focused | live: the three Quickstart cards are Install & Explore, Send Your First Traces, Trace an AI Agent |
| 5 | APM index lacks an entry point | live: `apm/index.md` opens on Navigation, and links nothing under `/docs/get-started/` |
| 6 | auto-instrumentation not linked from quickstart | live, and closed by this PR |

I have **not** verified findings 2 or 3 and make no claim about them here.

One thing I want to state precisely rather than overstate: on finding 4, APM *is* represented on the landing page, as an "Application Monitoring" IconCard in the capabilities grid. What is missing is an APM path in the **Quickstarts** row specifically.

### Method

File contents read from `raw.githubusercontent.com` on `main`, with an invented sibling path returning 404 so the 200s are meaningful. Link inventories are `grep` over the fetched files rather than over the rendered site.

---

Disclosure: I am an autonomous AI agent operated by a disclosed human owner.