### PR TITLE
fix(aws): grant AMP rule-group and silence permissions to Prometheus data source role (CLI + CDK)

### DIFF
--- a/aws/cdk/lib/prometheus.ts
+++ b/aws/cdk/lib/prometheus.ts
@@ -28,9 +28,18 @@ export class PrometheusConstruct extends Construct {
     this.dqsRole = new iam.Role(this, 'DqsRole', {
       assumedBy: new iam.ServicePrincipal('directquery.opensearchservice.amazonaws.com'),
     });
+    // The data source queries metrics AND manages alerting resources (alerting
+    // rule groups and alert-manager silences) in the workspace. AMP authorizes
+    // rule-groups-namespace CRUD (Put/Delete/DescribeRuleGroupsNamespace) against
+    // the rulegroupsnamespace ARN, NOT the workspace ARN, so granting aps:* only
+    // on the workspace ARN silently denies rule-group create/update/delete.
+    // Alert-manager definitions and silences resolve against the workspace ARN.
     this.dqsRole.addToPolicy(new iam.PolicyStatement({
       actions: ['aps:*'],
-      resources: [this.workspace.attrArn],
+      resources: [
+        this.workspace.attrArn,
+        `arn:${stack.partition}:aps:${stack.region}:${stack.account}:rulegroupsnamespace/${this.workspace.attrWorkspaceId}/*`,
+      ],
     }));
 
     const dqsDataSourceName = `prometheus_${stack.stackName}`.toLowerCase().replace(/[^a-z0-9_]/g, '_');

--- a/aws/cli-installer/src/aws.mjs
+++ b/aws/cli-installer/src/aws.mjs
@@ -1212,11 +1212,26 @@ export async function createConnectedDataSourceRole(cfg) {
     throw new Error('Failed to create Connected Data Source Prometheus role');
   }
 
-  // Attach APS access policy
+  // Attach APS access policy.
+  //
+  // The data source needs to query metrics AND manage alerting resources
+  // (alerting rule groups and alert-manager silences) in the workspace.
+  // AMP authorizes these against two different resource ARNs:
+  //   - Workspace-scoped actions (queries, remote write, alert-manager
+  //     definition + silences) resolve against the workspace ARN.
+  //   - Rule-groups-namespace CRUD (Put/Delete/DescribeRuleGroupsNamespace)
+  //     resolve against the rulegroupsnamespace ARN, NOT the workspace ARN.
+  // Granting aps:* only on the workspace ARN silently denies rule-group
+  // create/update/delete, so we list both resources.
   const apsWorkspaceArn = `arn:aws:aps:${cfg.region}:${cfg.accountId}:workspace/${cfg.apsWorkspaceId}`;
+  const apsRuleGroupsNamespaceArn = `arn:aws:aps:${cfg.region}:${cfg.accountId}:rulegroupsnamespace/${cfg.apsWorkspaceId}/*`;
   const permissionsPolicy = JSON.stringify({
     Version: '2012-10-17',
-    Statement: [{ Effect: 'Allow', Action: 'aps:*', Resource: apsWorkspaceArn }],
+    Statement: [{
+      Effect: 'Allow',
+      Action: 'aps:*',
+      Resource: [apsWorkspaceArn, apsRuleGroupsNamespaceArn],
+    }],
   });
 
   try {


### PR DESCRIPTION
## Description

The AWS deployment's **Prometheus Connected Data Source** role (assumed by `directquery.opensearchservice.amazonaws.com` to reach Amazon Managed Service for Prometheus) granted `aps:*` **only on the workspace ARN**.

AMP authorizes rule-groups-namespace CRUD against a *different* resource ARN than the workspace:

| Action | Resource ARN it resolves against |
|---|---|
| `aps:PutRuleGroupsNamespace` / `aps:DeleteRuleGroupsNamespace` / `aps:DescribeRuleGroupsNamespace` | `rulegroupsnamespace/<workspaceId>/<name>` |
| `aps:CreateRuleGroupsNamespace`, `aps:ListRuleGroupsNamespaces` | `workspace/<id>` |
| `aps:CreateAlertManagerDefinition` / `aps:PutAlertManagerDefinition` / `aps:DeleteAlertManagerDefinition`, `aps:PutAlertManagerSilences` (silences) | `workspace/<id>` |

Because the policy only listed the workspace ARN, **creating, updating, and deleting alerting rule groups was silently denied** (`AccessDenied`), while queries, remote-write, alert-manager definitions, and silences worked.

## Change

Add the `rulegroupsnamespace/<workspaceId>/*` resource to the data source role's APS policy so it can create/update/delete alerting rule groups. Silences and alert-manager definitions resolve against the workspace ARN and were already covered — the change makes both resources explicit. Fixed in **both** deployment paths, which build the role independently:

- **CLI installer** — `aws/cli-installer/src/aws.mjs` (`createConnectedDataSourceRole`)
- **CDK** — `aws/cdk/lib/prometheus.ts` (`DqsRole`)

## Testing

- `node --check aws/cli-installer/src/aws.mjs` passes.
- `tsc --noEmit` on `aws/cdk` passes.

## References

- [Understanding IAM permissions needed for using rules](https://docs.aws.amazon.com/prometheus/latest/userguide/AMP-ruler-IAM-permissions.html)
- [Managing and forwarding alerts with alert manager (`PutAlertManagerSilences`)](https://docs.aws.amazon.com/prometheus/latest/userguide/AMP-alert-manager.html)