### PR TITLE
feat(cli): select an AWS profile for installer commands

### DIFF
--- a/aws/cli-installer/README.md
+++ b/aws/cli-installer/README.md
@@ -123,6 +123,9 @@ node bin/cli-installer.mjs destroy \
 
 Deletes: EC2 instance, OpenSearch Application, Connected Data Source, OSIS pipeline, IAM roles. OpenSearch domain and AMP workspace are preserved (shared resources).
 
+Use `--profile NAME` to select credentials for create, destroy, or the demo launcher.
+`--profile NAME` alone opens the interactive CLI. See [AWS profile selection](https://observability.opensearch.org/docs/deploy/aws/#select-an-aws-profile) for precedence and examples.
+
 ## Prerequisites
 
 - Node.js 18+
@@ -171,6 +174,7 @@ node --test test/unit.test.mjs
 
 ### Key Patterns
 
+- **AWS profiles** — select once with `configureAwsProfile` before constructing clients or credential providers. All CLI commands use the process-wide SDK profile; do not cache a provider before this boundary.
 - **SigV4 signing** — `opensearch-ui-init.mjs` uses `@aws-sdk/signature-v4` with service `opensearch`. Query params must be in the `query` property of `HttpRequest`, not embedded in the path.
 - **Idempotency** — Every resource creation checks for existence first. Correlations use find-before-create; saved objects with fixed IDs are upserted.
 - **EC2 demo** — User data script installs Docker + Compose, clones the repo, writes a managed-mode collector config, and starts workload services via `docker-compose.managed.yml`.

--- a/aws/cli-installer/bin/launch-demo.mjs
+++ b/aws/cli-installer/bin/launch-demo.mjs
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 /**
  * Launch only the EC2 demo workload against an existing OSI pipeline.
- * Usage: AWS_PROFILE=<p> node bin/launch-demo.mjs --pipeline-name <name> --region <r>
+ * Usage: node bin/launch-demo.mjs --profile <p> --pipeline-name <name> --region <r>
  */
 import { Command } from 'commander';
+import { addProfileOption, configureAwsProfile } from '../src/aws-profile.mjs';
 import { OSISClient, GetPipelineCommand } from '@aws-sdk/client-osis';
 import { STSClient, GetCallerIdentityCommand } from '@aws-sdk/client-sts';
 import { launchDemoInstance } from '../src/ec2-demo.mjs';
@@ -12,8 +13,10 @@ import { printError, printInfo, printSuccess } from '../src/ui.mjs';
 const program = new Command()
   .requiredOption('--pipeline-name <name>', 'Existing OSI pipeline name')
   .requiredOption('--region <region>', 'AWS region');
+addProfileOption(program);
 program.parse(process.argv);
 const opts = program.opts();
+configureAwsProfile(opts.profile);
 
 try {
   const sts = new STSClient({ region: opts.region });

--- a/aws/cli-installer/src/aws-profile.mjs
+++ b/aws/cli-installer/src/aws-profile.mjs
@@ -1,0 +1,13 @@
+import { InvalidArgumentError } from 'commander';
+
+export function addProfileOption(program) {
+  return program.option('--profile <name>', 'AWS shared configuration profile', (value) => {
+    if (!value.trim()) throw new InvalidArgumentError('Profile name must not be empty.');
+    return value;
+  });
+}
+
+/** Select once, before creating SDK clients or SigV4 credential providers. */
+export function configureAwsProfile(profile) {
+  if (profile !== undefined) process.env.AWS_PROFILE = profile;
+}

--- a/aws/cli-installer/src/cli.mjs
+++ b/aws/cli-installer/src/cli.mjs
@@ -1,6 +1,7 @@
 import { Command } from 'commander';
 import { createRequire } from 'node:module';
 import { DEFAULTS } from './config.mjs';
+import { addProfileOption } from './aws-profile.mjs';
 
 const require = createRequire(import.meta.url);
 const { version: PKG_VERSION } = require('../package.json');
@@ -23,6 +24,8 @@ export function parseCli(argv) {
       'OpenSearch, Prometheus, IAM roles, and ingestion pipelines.'
     )
     .version(PKG_VERSION);
+
+  addProfileOption(program);
 
   // Mode
   program
@@ -94,7 +97,12 @@ export function parseCli(argv) {
 
   program.parse(argv);
 
-  return optsToConfig(program.opts());
+  const opts = program.opts();
+  const onlyProfile = opts.profile !== undefined && program.options.every((option) =>
+    option.name() === 'profile' || program.getOptionValueSource(option.name()) !== 'cli'
+  );
+  if (onlyProfile) return { _command: 'repl', profile: opts.profile };
+  return optsToConfig(opts);
 }
 
 function parseDestroyArgs(argv) {
@@ -106,6 +114,7 @@ function parseDestroyArgs(argv) {
     .option('--opensearch-password <password>', 'Master password (if domain was not created by CLI)')
     .option('--aoss-collection-name <name>', 'Collection name if it differs from the pipeline name');
 
+  addProfileOption(program);
   program.parse(argv.slice(1));
   return { _command: 'destroy', ...program.opts() };
 }
@@ -145,6 +154,7 @@ function optsToConfig(opts) {
 
   return {
     mode,
+    profile: opts.profile,
     pipelineName: opts.pipelineName,
     region: opts.region || '',
     opensearchType,

--- a/aws/cli-installer/src/main.mjs
+++ b/aws/cli-installer/src/main.mjs
@@ -1,4 +1,5 @@
 import { writeFileSync } from 'node:fs';
+import { configureAwsProfile } from './aws-profile.mjs';
 import { parseCli, applyQuickDefaults, validateConfig, fillDryRunPlaceholders } from './cli.mjs';
 import { renderPipeline } from './render.mjs';
 import {
@@ -33,7 +34,8 @@ export async function run() {
   try {
     // Parse CLI or run interactive REPL
     let cfg = parseCli(process.argv);
-    if (!cfg) {
+    configureAwsProfile(cfg?.profile);
+    if (!cfg || cfg._command === 'repl') {
       const { startRepl } = await import('./repl.mjs');
       return startRepl();
     }

--- a/aws/cli-installer/test/unit.test.mjs
+++ b/aws/cli-installer/test/unit.test.mjs
@@ -941,3 +941,83 @@ describe('renderArchitectureDiagram — VPC annotations', () => {
     assert.deepEqual(boxRowWidths(renderArchitectureDiagram(vpc())), boxRowWidths(renderArchitectureDiagram(pub())));
   });
 });
+
+// Profile selection is process-wide so SDK clients and SigV4 signers agree.
+import { parseCli } from '../src/cli.mjs';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+
+const installerDir = fileURLToPath(new URL('..', import.meta.url));
+
+describe('AWS profile selection', () => {
+  it('preserves interactive mode for a profile-only invocation', () => {
+    assert.equal(parseCli(['node', 'cli']), null);
+    for (const args of [['--profile', 'work'], ['--profile=work']]) {
+      assert.deepEqual(parseCli(['node', 'cli', ...args]), { _command: 'repl', profile: 'work' });
+    }
+  });
+
+  it('accepts profiles for creation and destruction without changing their mode', () => {
+    const create = parseCli(['node', 'cli', '--profile', 'work', '--quick', '--region', 'us-east-1']);
+    assert.equal(create.profile, 'work');
+    assert.equal(create.mode, 'quick');
+    const destroy = parseCli(['node', 'cli', 'destroy', '--profile', 'work', '--pipeline-name', 'test']);
+    assert.equal(destroy.profile, 'work');
+    assert.equal(destroy._command, 'destroy');
+  });
+
+  it('applies the profile at CLI startup without contacting AWS on a dry run', () => {
+    const hook = 'process.on("exit", () => { if (process.env.AWS_PROFILE !== "selected") process.exitCode = 1; })';
+    const result = execFileSync(process.execPath, [
+      '--import', `data:text/javascript,${encodeURIComponent(hook)}`,
+      'bin/cli-installer.mjs', '--profile', 'selected', '--region', 'us-east-1', '--dry-run',
+    ], { cwd: installerDir, env: { AWS_PROFILE: 'inherited' }, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+    assert.match(result, /source:/);
+  });
+
+  it('rejects empty profiles in every entrypoint before AWS access', () => {
+    for (const args of [
+      ['bin/cli-installer.mjs', '--profile', ''],
+      ['bin/cli-installer.mjs', 'destroy', '--pipeline-name', 'test', '--profile', '   '],
+      ['bin/launch-demo.mjs', '--pipeline-name', 'test', '--region', 'us-east-1', '--profile', ''],
+    ]) {
+      assert.throws(() => execFileSync(process.execPath, args, {
+        cwd: installerDir, env: {}, stdio: 'pipe', timeout: 5000,
+      }), (error) => /Profile name must not be empty/.test(error.stderr.toString()));
+    }
+  });
+
+  it('resolves one selected profile for service clients and signing providers', () => {
+    const temp = mkdtempSync(join(tmpdir(), 'obs-profile-'));
+    try {
+      const credentialsFile = join(temp, 'credentials');
+      const configFile = join(temp, 'config');
+      writeFileSync(credentialsFile, '[inherited]\naws_access_key_id=INHERITED\naws_secret_access_key=fixture\n[selected]\naws_access_key_id=SELECTED\naws_secret_access_key=fixture\n');
+      writeFileSync(configFile, '');
+      const script = `
+        import assert from 'node:assert/strict';
+        import { configureAwsProfile } from './src/aws-profile.mjs';
+        import { STSClient } from '@aws-sdk/client-sts';
+        import { EC2Client } from '@aws-sdk/client-ec2';
+        import { defaultProvider } from '@aws-sdk/credential-provider-node';
+        configureAwsProfile(process.argv[1] === 'inherit' ? undefined : process.argv[1]);
+        const providers = [new STSClient({ region: 'us-east-1' }).config.credentials,
+          new EC2Client({ region: 'us-east-1' }).config.credentials, defaultProvider()];
+        for (const provider of providers) {
+          if (process.argv[1] === 'missing') await assert.rejects(provider());
+          else assert.equal((await provider()).accessKeyId,
+            process.argv[1] === 'inherit' ? 'INHERITED' : 'SELECTED');
+        }
+      `;
+      for (const selection of ['selected', 'inherit', 'missing']) {
+        execFileSync(process.execPath, ['--input-type=module', '-e', script, selection], {
+          cwd: installerDir, stdio: 'pipe', timeout: 10000,
+          env: { AWS_PROFILE: 'inherited', AWS_SHARED_CREDENTIALS_FILE: credentialsFile,
+            AWS_CONFIG_FILE: configFile, AWS_EC2_METADATA_DISABLED: 'true' },
+        });
+      }
+    } finally {
+      rmSync(temp, { recursive: true, force: true });
+    }
+  });
+});

--- a/docs/starlight-docs/src/content/docs/deploy/aws.mdx
+++ b/docs/starlight-docs/src/content/docs/deploy/aws.mdx
@@ -39,6 +39,30 @@ npx @opensearch-project/observability-stack --serverless
 
 Takes ~15 minutes. See [aws/cli-installer/README.md](https://github.com/opensearch-project/observability-stack/tree/main/aws/cli-installer) for full options.
 
+#### Select an AWS profile
+
+Pass `--profile NAME` to use a named profile from your AWS shared configuration.
+With no other flags, the CLI opens the interactive menu using that profile:
+
+```bash
+npx @opensearch-project/observability-stack --profile development
+```
+
+Combine it with deployment flags for a non-interactive invocation:
+
+```bash
+npx @opensearch-project/observability-stack --profile development --quick --region us-east-1
+```
+
+The profile applies to credential checks, resource operations, and signed OpenSearch
+requests for the command's lifetime. `--profile` overrides `AWS_PROFILE`; omitting
+it preserves the SDK's existing credential selection. Region selection is unchanged.
+The CLI does not edit your AWS configuration files.
+
+Use the same profile when running `destroy --pipeline-name NAME --profile development`
+or the repository's `bin/launch-demo.mjs --profile development` command. If a profile
+uses SSO, sign in with `aws sso login --profile development` first.
+
 #### Deploy into a VPC
 
 Pass `--vpc-id` with `--subnet-ids` and `--security-group-ids` to place the OpenSearch domain, the OSIS ingestion pipeline, and the EC2 demo instance inside a VPC on private endpoints. Omit `--vpc-id` and you get the default public-endpoint deployment. VPC mode requires the managed backend.


### PR DESCRIPTION
### Description

Add `--profile NAME` to the AWS installer, destroy command, and standalone demo launcher. `--profile NAME` alone opens the interactive CLI; combining it with deployment flags retains the existing non-interactive flow.

The command selects `AWS_PROFILE` before creating SDK clients or signing credential providers, so credential checks, resource operations, and SigV4 requests use the same SDK profile selection. An explicit flag overrides the inherited profile; omitting it preserves the existing SDK credential chain. Blank profile names are rejected. Region behavior and AWS configuration files are unchanged.

Public deployment docs describe usage and precedence. The contributor README records the initialization boundary. The existing docs page title and description are unchanged, so the generated llms.txt index does not require regeneration.

### Issues Resolved

Closes #395.

### Validation

- Reproduced before implementation: the real installer rejected `--profile` as an unknown option.
- `npm test` in `aws/cli-installer`: **139 passed** on Node 26.
- The same unit and e2e-unit files on CI's Node 24: **139 passed**.
- Tests cover profile-only interactive routing, create/destroy parsing, the real dry-run entrypoint, blank profile rejection in all entrypoints, and real SDK service/signing credential providers using isolated temporary credential files. Profile tests make no AWS API calls.
- `npm run build` in `docs`: passed, including the nested Starlight build and link validation (148 documentation pages).
- `git diff --check`: passed.

Implemented and reviewed by Codex. No live AWS deployment was performed; cloud provisioning and SSO login are not claimed as validated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
