### PR TITLE
docs: point the first-traces quickstart at auto-instrumentation and APM

### DIFF
--- a/docs/starlight-docs/src/content/docs/get-started/quickstart/first-traces.md
+++ b/docs/starlight-docs/src/content/docs/get-started/quickstart/first-traces.md
@@ -9,6 +9,13 @@ description: Instrument your application to send traces to the Observability Sta
 pip install opentelemetry-api opentelemetry-sdk opentelemetry-exporter-otlp
 ```
 
+:::tip[OpenTelemetry auto-instrumentation]
+The example below instruments a span by hand so you can see what a trace is made
+of. For a real service, [auto-instrumentation](/docs/send-data/opentelemetry/auto-instrumentation/)
+is usually the faster path: it emits HTTP, database and framework spans with no
+code changes, and is available for Python, Java, Node.js, Go, .NET and Ruby.
+:::
+
 ## 2. Send traces
 
 ```python
@@ -46,4 +53,5 @@ For other languages, see [Send Data](/docs/send-data/).
 
 - [Create Your First Dashboard](/docs/get-started/quickstart/first-dashboard/) - build custom visualizations
 - [Agent Tracing](/docs/ai-observability/agent-tracing/) - trace AI agent workflows with GenAI semantic conventions
+- [Application Monitoring](/docs/apm/) - service maps and RED metrics built from the traces you just sent
 - [Send Data](/docs/send-data/) - more instrumentation options


### PR DESCRIPTION
Addresses findings 6 and part of 1 from #112, in the one file where both are visible. Two additions, one file, nothing moved or reworded.

### 1. The quickstart never mentions auto-instrumentation

first-traces.md teaches manual span creation and links only to /docs/send-data/ for "other languages". #112 calls auto-instrumentation "the 80% path for APM users", and it is already documented for six languages, but the getting-started flow never points at it. A reader following this page writes code they probably do not need to write. Adds a tip right after the manual span example.

### 2. No link from first-traces to Application Monitoring

Adds a Next steps link to Application Monitoring so a reader who just sent their first trace can find the service maps and RED metrics built from it.

Both review comments from the original PR (kylehounslow review 4977234137, the tip title wording) are already applied in this diff.

Replaces #427. That PR's second commit (994cbf2) is missing its DCO sign-off, and this repo has no .github/dco.yml enabling a remediation commit, so per the DCO app's own guidance the only fix that does not force-push an open PR is a fresh, correctly signed PR carrying the same diff. Closing #427 with this one linked.
